### PR TITLE
#18: Создать REST API контроллеры

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
@@ -2,9 +2,9 @@ package com.github.mihanizzm.ultistats.controller
 
 import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
 import com.github.mihanizzm.ultistats.dto.response.EventResponse
-import com.github.mihanizzm.ultistats.model.events.*
-import com.github.mihanizzm.ultistats.service.EventService
-import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.facade.EventFacade
+import com.github.mihanizzm.ultistats.facade.EventResult
+import com.github.mihanizzm.ultistats.model.events.Event
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -16,32 +16,28 @@ import java.util.UUID
 @RequestMapping("/api/matches/{matchId}/events")
 @Tag(name = "Events", description = "Управление событиями матча")
 class EventController(
-    private val eventService: EventService,
-    private val matchService: MatchService,
+    private val eventFacade: EventFacade,
 ) {
     @GetMapping
     @Operation(summary = "Получить все события матча")
-    fun getAll(@PathVariable matchId: UUID): ResponseEntity<List<Event>> {
-        if (matchService.get(matchId) == null) {
-            return ResponseEntity.notFound().build()
+    fun getAll(@PathVariable matchId: UUID): ResponseEntity<List<Event>> =
+        when (val result = eventFacade.getAll(matchId)) {
+            is EventResult.EventList -> ResponseEntity.ok(result.events)
+            else -> ResponseEntity.notFound().build()
         }
-        return ResponseEntity.ok(eventService.getAllEventsOfMatch(matchId))
-    }
 
     @PostMapping
     @Operation(summary = "Создать событие")
     fun create(
         @PathVariable matchId: UUID,
         @RequestBody request: CreateEventRequest
-    ): ResponseEntity<EventResponse> {
-        if (matchService.get(matchId) == null) {
-            return ResponseEntity.notFound().build()
+    ): ResponseEntity<EventResponse> =
+        when (val result = eventFacade.create(matchId, request)) {
+            is EventResult.Success -> ResponseEntity.status(HttpStatus.CREATED).body(result.response)
+            is EventResult.NotFound -> ResponseEntity.notFound().build()
+            is EventResult.BadRequest -> ResponseEntity.badRequest().build()
+            else -> ResponseEntity.internalServerError().build()
         }
-        val event = createEventFromRequest(request)
-            ?: return ResponseEntity.badRequest().build()
-        val diskHolderId = eventService.create(event, matchId)
-        return ResponseEntity.status(HttpStatus.CREATED).body(EventResponse(diskHolderId))
-    }
 
     @PutMapping("/{index}")
     @Operation(summary = "Изменить событие по индексу")
@@ -49,153 +45,23 @@ class EventController(
         @PathVariable matchId: UUID,
         @PathVariable index: Int,
         @RequestBody request: CreateEventRequest
-    ): ResponseEntity<EventResponse> {
-        if (matchService.get(matchId) == null) {
-            return ResponseEntity.notFound().build()
+    ): ResponseEntity<EventResponse> =
+        when (val result = eventFacade.edit(matchId, index, request)) {
+            is EventResult.Success -> ResponseEntity.ok(result.response)
+            is EventResult.NotFound -> ResponseEntity.notFound().build()
+            is EventResult.BadRequest -> ResponseEntity.badRequest().build()
+            else -> ResponseEntity.internalServerError().build()
         }
-        val event = createEventFromRequest(request)
-            ?: return ResponseEntity.badRequest().build()
-        return try {
-            val diskHolderId = eventService.edit(index, event, matchId)
-            ResponseEntity.ok(EventResponse(diskHolderId))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.notFound().build()
-        }
-    }
 
     @DeleteMapping("/{index}")
     @Operation(summary = "Удалить событие по индексу")
     fun delete(
         @PathVariable matchId: UUID,
         @PathVariable index: Int
-    ): ResponseEntity<EventResponse> {
-        if (matchService.get(matchId) == null) {
-            return ResponseEntity.notFound().build()
+    ): ResponseEntity<EventResponse> =
+        when (val result = eventFacade.delete(matchId, index)) {
+            is EventResult.Success -> ResponseEntity.ok(result.response)
+            is EventResult.NotFound -> ResponseEntity.notFound().build()
+            else -> ResponseEntity.internalServerError().build()
         }
-        return try {
-            val diskHolderId = eventService.remove(index, matchId)
-            ResponseEntity.ok(EventResponse(diskHolderId))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.notFound().build()
-        }
-    }
-
-    private fun createEventFromRequest(request: CreateEventRequest): Event? {
-        return when (request.type) {
-            EventType.PASS -> {
-                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
-                PassEvent(
-                    fromPlayer = request.playerId,
-                    toPlayer = request.toPlayerId,
-                    fromTeam = request.teamId,
-                    toTeam = request.toTeamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.GOAL -> {
-                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
-                GoalEvent(
-                    fromPlayer = request.playerId,
-                    toPlayer = request.toPlayerId,
-                    fromTeam = request.teamId,
-                    toTeam = request.toTeamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.DROP -> {
-                if (request.playerId == null) return null
-                DropEvent(
-                    player = request.playerId,
-                    team = request.teamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.PULL -> {
-                if (request.playerId == null) return null
-                PullEvent(
-                    player = request.playerId,
-                    team = request.teamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.BRICK -> {
-                if (request.playerId == null) return null
-                BrickEvent(
-                    player = request.playerId,
-                    team = request.teamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.TURNOVER -> {
-                if (request.playerId == null) return null
-                TurnoverEvent(
-                    player = request.playerId,
-                    team = request.teamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.BLOCK_MARKER -> {
-                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
-                BlockMarkerEvent(
-                    fromPlayer = request.playerId,
-                    toPlayer = request.toPlayerId,
-                    fromTeam = request.teamId,
-                    toTeam = request.toTeamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.BLOCK_FIELD -> {
-                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
-                BlockFieldEvent(
-                    fromPlayer = request.playerId,
-                    toPlayer = request.toPlayerId,
-                    fromTeam = request.teamId,
-                    toTeam = request.toTeamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.INTERCEPTION -> {
-                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
-                InterceptionEvent(
-                    fromPlayer = request.playerId,
-                    toPlayer = request.toPlayerId,
-                    fromTeam = request.teamId,
-                    toTeam = request.toTeamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.CALLAHAN -> {
-                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
-                CallahanEvent(
-                    fromPlayer = request.playerId,
-                    toPlayer = request.toPlayerId,
-                    fromTeam = request.teamId,
-                    toTeam = request.toTeamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.TIMEOUT_START -> {
-                TimeoutStartEvent(
-                    team = request.teamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.TIMEOUT_END -> {
-                TimeoutEndEvent(
-                    team = request.teamId,
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.HALFTIME_START -> {
-                HalftimeStartEvent(
-                    realTimestamp = request.timestamp,
-                )
-            }
-            EventType.HALFTIME_END -> {
-                HalftimeEndEvent(
-                    realTimestamp = request.timestamp,
-                )
-            }
-        }
-    }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
@@ -1,0 +1,201 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.dto.response.EventResponse
+import com.github.mihanizzm.ultistats.model.events.*
+import com.github.mihanizzm.ultistats.service.EventService
+import com.github.mihanizzm.ultistats.service.MatchService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/matches/{matchId}/events")
+@Tag(name = "Events", description = "Управление событиями матча")
+class EventController(
+    private val eventService: EventService,
+    private val matchService: MatchService,
+) {
+    @GetMapping
+    @Operation(summary = "Получить все события матча")
+    fun getAll(@PathVariable matchId: UUID): ResponseEntity<List<Event>> {
+        if (matchService.get(matchId) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        return ResponseEntity.ok(eventService.getAllEventsOfMatch(matchId))
+    }
+
+    @PostMapping
+    @Operation(summary = "Создать событие")
+    fun create(
+        @PathVariable matchId: UUID,
+        @RequestBody request: CreateEventRequest
+    ): ResponseEntity<EventResponse> {
+        if (matchService.get(matchId) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        val event = createEventFromRequest(request)
+            ?: return ResponseEntity.badRequest().build()
+        val diskHolderId = eventService.create(event, matchId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(EventResponse(diskHolderId))
+    }
+
+    @PutMapping("/{index}")
+    @Operation(summary = "Изменить событие по индексу")
+    fun edit(
+        @PathVariable matchId: UUID,
+        @PathVariable index: Int,
+        @RequestBody request: CreateEventRequest
+    ): ResponseEntity<EventResponse> {
+        if (matchService.get(matchId) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        val event = createEventFromRequest(request)
+            ?: return ResponseEntity.badRequest().build()
+        return try {
+            val diskHolderId = eventService.edit(index, event, matchId)
+            ResponseEntity.ok(EventResponse(diskHolderId))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    @DeleteMapping("/{index}")
+    @Operation(summary = "Удалить событие по индексу")
+    fun delete(
+        @PathVariable matchId: UUID,
+        @PathVariable index: Int
+    ): ResponseEntity<EventResponse> {
+        if (matchService.get(matchId) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        return try {
+            val diskHolderId = eventService.remove(index, matchId)
+            ResponseEntity.ok(EventResponse(diskHolderId))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    private fun createEventFromRequest(request: CreateEventRequest): Event? {
+        return when (request.type) {
+            EventType.PASS -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                PassEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.GOAL -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                GoalEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.DROP -> {
+                if (request.playerId == null) return null
+                DropEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.PULL -> {
+                if (request.playerId == null) return null
+                PullEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.BRICK -> {
+                if (request.playerId == null) return null
+                BrickEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.TURNOVER -> {
+                if (request.playerId == null) return null
+                TurnoverEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.BLOCK_MARKER -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                BlockMarkerEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.BLOCK_FIELD -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                BlockFieldEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.INTERCEPTION -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                InterceptionEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.CALLAHAN -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                CallahanEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.TIMEOUT_START -> {
+                TimeoutStartEvent(
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.TIMEOUT_END -> {
+                TimeoutEndEvent(
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.HALFTIME_START -> {
+                HalftimeStartEvent(
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.HALFTIME_END -> {
+                HalftimeEndEvent(
+                    realTimestamp = request.timestamp,
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -1,0 +1,59 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.response.MatchResponse
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.TeamService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/matches")
+@Tag(name = "Matches", description = "Управление матчами")
+class MatchController(
+    private val matchService: MatchService,
+    private val teamService: TeamService,
+) {
+    @GetMapping
+    @Operation(summary = "Получить все матчи")
+    fun getAll(): List<MatchResponse> =
+        matchService.getAll().map { MatchResponse.from(it) }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Получить матч по ID")
+    fun getById(@PathVariable id: UUID): ResponseEntity<MatchResponse> {
+        val match = matchService.get(id) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(MatchResponse.from(match))
+    }
+
+    @PostMapping
+    @Operation(summary = "Создать матч")
+    fun create(@RequestBody request: CreateMatchRequest): ResponseEntity<MatchResponse> {
+        val teams = teamService.getAllInList(request.teamIds)
+        if (teams.size != request.teamIds.size) {
+            return ResponseEntity.badRequest().build()
+        }
+        val match = Match(
+            id = UUID.randomUUID(),
+            teams = teams,
+        )
+        matchService.create(match)
+        return ResponseEntity.status(HttpStatus.CREATED).body(MatchResponse.from(match))
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Удалить матч")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: UUID): ResponseEntity<Unit> {
+        if (matchService.get(id) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        matchService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -2,9 +2,7 @@ package com.github.mihanizzm.ultistats.controller
 
 import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
-import com.github.mihanizzm.ultistats.model.Match
-import com.github.mihanizzm.ultistats.service.MatchService
-import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.facade.MatchFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -16,44 +14,30 @@ import java.util.UUID
 @RequestMapping("/api/matches")
 @Tag(name = "Matches", description = "Управление матчами")
 class MatchController(
-    private val matchService: MatchService,
-    private val teamService: TeamService,
+    private val matchFacade: MatchFacade,
 ) {
     @GetMapping
     @Operation(summary = "Получить все матчи")
-    fun getAll(): List<MatchResponse> =
-        matchService.getAll().map { MatchResponse.from(it) }
+    fun getAll(): List<MatchResponse> = matchFacade.getAll()
 
     @GetMapping("/{id}")
     @Operation(summary = "Получить матч по ID")
-    fun getById(@PathVariable id: UUID): ResponseEntity<MatchResponse> {
-        val match = matchService.get(id) ?: return ResponseEntity.notFound().build()
-        return ResponseEntity.ok(MatchResponse.from(match))
-    }
+    fun getById(@PathVariable id: UUID): ResponseEntity<MatchResponse> =
+        matchFacade.getById(id)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
 
     @PostMapping
     @Operation(summary = "Создать матч")
-    fun create(@RequestBody request: CreateMatchRequest): ResponseEntity<MatchResponse> {
-        val teams = teamService.getAllInList(request.teamIds)
-        if (teams.size != request.teamIds.size) {
-            return ResponseEntity.badRequest().build()
-        }
-        val match = Match(
-            id = UUID.randomUUID(),
-            teams = teams,
-        )
-        matchService.create(match)
-        return ResponseEntity.status(HttpStatus.CREATED).body(MatchResponse.from(match))
-    }
+    fun create(@RequestBody request: CreateMatchRequest): ResponseEntity<MatchResponse> =
+        matchFacade.create(request)
+            ?.let { ResponseEntity.status(HttpStatus.CREATED).body(it) }
+            ?: ResponseEntity.badRequest().build()
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Удалить матч")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun delete(@PathVariable id: UUID): ResponseEntity<Unit> {
-        if (matchService.get(id) == null) {
-            return ResponseEntity.notFound().build()
-        }
-        matchService.delete(id)
-        return ResponseEntity.noContent().build()
-    }
+    fun delete(@PathVariable id: UUID): ResponseEntity<Unit> =
+        if (matchFacade.delete(id)) ResponseEntity.noContent().build()
+        else ResponseEntity.notFound().build()
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
@@ -1,0 +1,28 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.statistics.StatisticsService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/matches/{matchId}/statistics")
+@Tag(name = "Statistics", description = "Получение статистики матча")
+class StatisticsController(
+    private val statisticsService: StatisticsService,
+    private val matchService: MatchService,
+) {
+    @GetMapping
+    @Operation(summary = "Получить статистику матча")
+    fun getStatistics(@PathVariable matchId: UUID): ResponseEntity<MatchStatistics> {
+        if (matchService.get(matchId) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        val statistics = statisticsService.recalculateMatchStatistics(matchId)
+        return ResponseEntity.ok(statistics)
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -3,9 +3,7 @@ package com.github.mihanizzm.ultistats.controller
 import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
 import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
 import com.github.mihanizzm.ultistats.dto.response.TeamResponse
-import com.github.mihanizzm.ultistats.model.Player
-import com.github.mihanizzm.ultistats.model.Team
-import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.facade.TeamFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
@@ -17,108 +15,55 @@ import java.util.UUID
 @RequestMapping("/api/teams")
 @Tag(name = "Teams", description = "Управление командами")
 class TeamController(
-    private val teamService: TeamService,
+    private val teamFacade: TeamFacade,
 ) {
     @GetMapping
     @Operation(summary = "Получить все команды")
-    fun getAll(): List<TeamResponse> =
-        teamService.getAll().map { TeamResponse.from(it) }
+    fun getAll(): List<TeamResponse> = teamFacade.getAll()
 
     @GetMapping("/{id}")
     @Operation(summary = "Получить команду по ID")
-    fun getById(@PathVariable id: UUID): ResponseEntity<TeamResponse> {
-        val team = teamService.get(id) ?: return ResponseEntity.notFound().build()
-        return ResponseEntity.ok(TeamResponse.from(team))
-    }
+    fun getById(@PathVariable id: UUID): ResponseEntity<TeamResponse> =
+        teamFacade.getById(id)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
 
     @PostMapping
     @Operation(summary = "Создать команду")
-    fun create(@RequestBody request: CreateTeamRequest): ResponseEntity<TeamResponse> {
-        val teamId = UUID.randomUUID()
-        val players = request.players.map { playerRequest ->
-            Player(
-                id = UUID.randomUUID(),
-                teamId = teamId,
-                number = playerRequest.number,
-                firstName = playerRequest.firstName,
-                lastName = playerRequest.lastName,
-            )
-        }
-        val team = Team(
-            id = teamId,
-            name = request.name,
-            players = players,
-        )
-        teamService.create(team)
-        return ResponseEntity.status(HttpStatus.CREATED).body(TeamResponse.from(team))
-    }
+    fun create(@RequestBody request: CreateTeamRequest): ResponseEntity<TeamResponse> =
+        ResponseEntity.status(HttpStatus.CREATED).body(teamFacade.create(request))
 
     @PutMapping("/{id}")
     @Operation(summary = "Обновить команду")
-    fun update(@PathVariable id: UUID, @RequestBody request: CreateTeamRequest): ResponseEntity<TeamResponse> {
-        val existingTeam = teamService.get(id) ?: return ResponseEntity.notFound().build()
-        val players = request.players.map { playerRequest ->
-            Player(
-                id = UUID.randomUUID(),
-                teamId = id,
-                number = playerRequest.number,
-                firstName = playerRequest.firstName,
-                lastName = playerRequest.lastName,
-            )
-        }
-        val updatedTeam = existingTeam.copy(
-            name = request.name,
-            players = players,
-        )
-        teamService.delete(id)
-        teamService.create(updatedTeam)
-        return ResponseEntity.ok(TeamResponse.from(updatedTeam))
-    }
+    fun update(@PathVariable id: UUID, @RequestBody request: CreateTeamRequest): ResponseEntity<TeamResponse> =
+        teamFacade.update(id, request)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Удалить команду")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun delete(@PathVariable id: UUID): ResponseEntity<Unit> {
-        if (teamService.get(id) == null) {
-            return ResponseEntity.notFound().build()
-        }
-        teamService.delete(id)
-        return ResponseEntity.noContent().build()
-    }
+    fun delete(@PathVariable id: UUID): ResponseEntity<Unit> =
+        if (teamFacade.delete(id)) ResponseEntity.noContent().build()
+        else ResponseEntity.notFound().build()
 
     @PostMapping("/{teamId}/players")
     @Operation(summary = "Добавить игрока в команду")
     fun addPlayer(
         @PathVariable teamId: UUID,
         @RequestBody request: CreatePlayerRequest
-    ): ResponseEntity<TeamResponse> {
-        val team = teamService.get(teamId) ?: return ResponseEntity.notFound().build()
-        val newPlayer = Player(
-            id = UUID.randomUUID(),
-            teamId = teamId,
-            number = request.number,
-            firstName = request.firstName,
-            lastName = request.lastName,
-        )
-        val updatedTeam = team.copy(players = team.players + newPlayer)
-        teamService.delete(teamId)
-        teamService.create(updatedTeam)
-        return ResponseEntity.status(HttpStatus.CREATED).body(TeamResponse.from(updatedTeam))
-    }
+    ): ResponseEntity<TeamResponse> =
+        teamFacade.addPlayer(teamId, request)
+            ?.let { ResponseEntity.status(HttpStatus.CREATED).body(it) }
+            ?: ResponseEntity.notFound().build()
 
     @DeleteMapping("/{teamId}/players/{playerId}")
     @Operation(summary = "Удалить игрока из команды")
     fun removePlayer(
         @PathVariable teamId: UUID,
         @PathVariable playerId: UUID
-    ): ResponseEntity<TeamResponse> {
-        val team = teamService.get(teamId) ?: return ResponseEntity.notFound().build()
-        if (!team.hasPlayer(playerId)) {
-            return ResponseEntity.notFound().build()
-        }
-        val updatedTeam = team.copy(players = team.players.filter { it.id != playerId })
-        teamService.delete(teamId)
-        teamService.create(updatedTeam)
-        return ResponseEntity.ok(TeamResponse.from(updatedTeam))
-    }
+    ): ResponseEntity<TeamResponse> =
+        teamFacade.removePlayer(teamId, playerId)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -1,0 +1,124 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
+import com.github.mihanizzm.ultistats.dto.response.TeamResponse
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.service.TeamService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/teams")
+@Tag(name = "Teams", description = "Управление командами")
+class TeamController(
+    private val teamService: TeamService,
+) {
+    @GetMapping
+    @Operation(summary = "Получить все команды")
+    fun getAll(): List<TeamResponse> =
+        teamService.getAll().map { TeamResponse.from(it) }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Получить команду по ID")
+    fun getById(@PathVariable id: UUID): ResponseEntity<TeamResponse> {
+        val team = teamService.get(id) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(TeamResponse.from(team))
+    }
+
+    @PostMapping
+    @Operation(summary = "Создать команду")
+    fun create(@RequestBody request: CreateTeamRequest): ResponseEntity<TeamResponse> {
+        val teamId = UUID.randomUUID()
+        val players = request.players.map { playerRequest ->
+            Player(
+                id = UUID.randomUUID(),
+                teamId = teamId,
+                number = playerRequest.number,
+                firstName = playerRequest.firstName,
+                lastName = playerRequest.lastName,
+            )
+        }
+        val team = Team(
+            id = teamId,
+            name = request.name,
+            players = players,
+        )
+        teamService.create(team)
+        return ResponseEntity.status(HttpStatus.CREATED).body(TeamResponse.from(team))
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Обновить команду")
+    fun update(@PathVariable id: UUID, @RequestBody request: CreateTeamRequest): ResponseEntity<TeamResponse> {
+        val existingTeam = teamService.get(id) ?: return ResponseEntity.notFound().build()
+        val players = request.players.map { playerRequest ->
+            Player(
+                id = UUID.randomUUID(),
+                teamId = id,
+                number = playerRequest.number,
+                firstName = playerRequest.firstName,
+                lastName = playerRequest.lastName,
+            )
+        }
+        val updatedTeam = existingTeam.copy(
+            name = request.name,
+            players = players,
+        )
+        teamService.delete(id)
+        teamService.create(updatedTeam)
+        return ResponseEntity.ok(TeamResponse.from(updatedTeam))
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Удалить команду")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: UUID): ResponseEntity<Unit> {
+        if (teamService.get(id) == null) {
+            return ResponseEntity.notFound().build()
+        }
+        teamService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/{teamId}/players")
+    @Operation(summary = "Добавить игрока в команду")
+    fun addPlayer(
+        @PathVariable teamId: UUID,
+        @RequestBody request: CreatePlayerRequest
+    ): ResponseEntity<TeamResponse> {
+        val team = teamService.get(teamId) ?: return ResponseEntity.notFound().build()
+        val newPlayer = Player(
+            id = UUID.randomUUID(),
+            teamId = teamId,
+            number = request.number,
+            firstName = request.firstName,
+            lastName = request.lastName,
+        )
+        val updatedTeam = team.copy(players = team.players + newPlayer)
+        teamService.delete(teamId)
+        teamService.create(updatedTeam)
+        return ResponseEntity.status(HttpStatus.CREATED).body(TeamResponse.from(updatedTeam))
+    }
+
+    @DeleteMapping("/{teamId}/players/{playerId}")
+    @Operation(summary = "Удалить игрока из команды")
+    fun removePlayer(
+        @PathVariable teamId: UUID,
+        @PathVariable playerId: UUID
+    ): ResponseEntity<TeamResponse> {
+        val team = teamService.get(teamId) ?: return ResponseEntity.notFound().build()
+        if (!team.hasPlayer(playerId)) {
+            return ResponseEntity.notFound().build()
+        }
+        val updatedTeam = team.copy(players = team.players.filter { it.id != playerId })
+        teamService.delete(teamId)
+        teamService.create(updatedTeam)
+        return ResponseEntity.ok(TeamResponse.from(updatedTeam))
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateEventRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateEventRequest.kt
@@ -1,0 +1,14 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+import com.github.mihanizzm.ultistats.model.events.EventType
+import java.time.Instant
+import java.util.UUID
+
+data class CreateEventRequest(
+    val type: EventType,
+    val timestamp: Instant,
+    val teamId: UUID,
+    val playerId: UUID? = null,
+    val toTeamId: UUID? = null,
+    val toPlayerId: UUID? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateMatchRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateMatchRequest.kt
@@ -1,0 +1,7 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+import java.util.UUID
+
+data class CreateMatchRequest(
+    val teamIds: List<UUID>,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreatePlayerRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreatePlayerRequest.kt
@@ -1,0 +1,7 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+data class CreatePlayerRequest(
+    val number: Int?,
+    val firstName: String,
+    val lastName: String,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateTeamRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateTeamRequest.kt
@@ -1,0 +1,6 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+data class CreateTeamRequest(
+    val name: String,
+    val players: List<CreatePlayerRequest> = emptyList(),
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/EventResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/EventResponse.kt
@@ -1,0 +1,7 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import java.util.UUID
+
+data class EventResponse(
+    val diskHolderId: UUID?,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
@@ -1,0 +1,20 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.Match
+import java.util.UUID
+
+data class MatchResponse(
+    val id: UUID,
+    val teams: List<TeamResponse>,
+    val eventCount: Int,
+    val diskHolderId: UUID?,
+) {
+    companion object {
+        fun from(match: Match) = MatchResponse(
+            id = match.id,
+            teams = match.teams.map { TeamResponse.from(it) },
+            eventCount = match.events.size,
+            diskHolderId = match.diskHolderId,
+        )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/PlayerResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/PlayerResponse.kt
@@ -1,0 +1,22 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.Player
+import java.util.UUID
+
+data class PlayerResponse(
+    val id: UUID?,
+    val teamId: UUID,
+    val number: Int?,
+    val firstName: String,
+    val lastName: String,
+) {
+    companion object {
+        fun from(player: Player) = PlayerResponse(
+            id = player.id,
+            teamId = player.teamId,
+            number = player.number,
+            firstName = player.firstName,
+            lastName = player.lastName,
+        )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamResponse.kt
@@ -1,0 +1,18 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.Team
+import java.util.UUID
+
+data class TeamResponse(
+    val id: UUID,
+    val name: String,
+    val players: List<PlayerResponse>,
+) {
+    companion object {
+        fun from(team: Team) = TeamResponse(
+            id = team.id,
+            name = team.name,
+            players = team.players.map { PlayerResponse.from(it) },
+        )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/EventFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/EventFacade.kt
@@ -1,0 +1,67 @@
+package com.github.mihanizzm.ultistats.facade
+
+import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.dto.response.EventResponse
+import com.github.mihanizzm.ultistats.factory.EventFactory
+import com.github.mihanizzm.ultistats.model.events.Event
+import com.github.mihanizzm.ultistats.service.EventService
+import com.github.mihanizzm.ultistats.service.MatchService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+sealed class EventResult {
+    data class Success(val response: EventResponse) : EventResult()
+    data class EventList(val events: List<Event>) : EventResult()
+    object NotFound : EventResult()
+    object BadRequest : EventResult()
+}
+
+@Component
+class EventFacade(
+    private val eventService: EventService,
+    private val matchService: MatchService,
+    private val eventFactory: EventFactory,
+) {
+    fun getAll(matchId: UUID): EventResult {
+        if (matchService.get(matchId) == null) {
+            return EventResult.NotFound
+        }
+        return EventResult.EventList(eventService.getAllEventsOfMatch(matchId))
+    }
+
+    fun create(matchId: UUID, request: CreateEventRequest): EventResult {
+        if (matchService.get(matchId) == null) {
+            return EventResult.NotFound
+        }
+        val event = eventFactory.createFromRequest(request)
+            ?: return EventResult.BadRequest
+        val diskHolderId = eventService.create(event, matchId)
+        return EventResult.Success(EventResponse(diskHolderId))
+    }
+
+    fun edit(matchId: UUID, index: Int, request: CreateEventRequest): EventResult {
+        if (matchService.get(matchId) == null) {
+            return EventResult.NotFound
+        }
+        val event = eventFactory.createFromRequest(request)
+            ?: return EventResult.BadRequest
+        return try {
+            val diskHolderId = eventService.edit(index, event, matchId)
+            EventResult.Success(EventResponse(diskHolderId))
+        } catch (e: IllegalArgumentException) {
+            EventResult.NotFound
+        }
+    }
+
+    fun delete(matchId: UUID, index: Int): EventResult {
+        if (matchService.get(matchId) == null) {
+            return EventResult.NotFound
+        }
+        return try {
+            val diskHolderId = eventService.remove(index, matchId)
+            EventResult.Success(EventResponse(diskHolderId))
+        } catch (e: IllegalArgumentException) {
+            EventResult.NotFound
+        }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
@@ -1,0 +1,42 @@
+package com.github.mihanizzm.ultistats.facade
+
+import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.response.MatchResponse
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class MatchFacade(
+    private val matchService: MatchService,
+    private val teamService: TeamService,
+) {
+    fun getAll(): List<MatchResponse> =
+        matchService.getAll().map { MatchResponse.from(it) }
+
+    fun getById(id: UUID): MatchResponse? {
+        val match = matchService.get(id) ?: return null
+        return MatchResponse.from(match)
+    }
+
+    fun create(request: CreateMatchRequest): MatchResponse? {
+        val teams = teamService.getAllInList(request.teamIds)
+        if (teams.size != request.teamIds.size) {
+            return null
+        }
+        val match = Match(
+            id = UUID.randomUUID(),
+            teams = teams,
+        )
+        matchService.create(match)
+        return MatchResponse.from(match)
+    }
+
+    fun delete(id: UUID): Boolean {
+        if (matchService.get(id) == null) return false
+        matchService.delete(id)
+        return true
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
@@ -1,0 +1,79 @@
+package com.github.mihanizzm.ultistats.facade
+
+import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
+import com.github.mihanizzm.ultistats.dto.response.TeamResponse
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class TeamFacade(
+    private val teamService: TeamService,
+) {
+    fun getAll(): List<TeamResponse> =
+        teamService.getAll().map { TeamResponse.from(it) }
+
+    fun getById(id: UUID): TeamResponse? {
+        val team = teamService.get(id) ?: return null
+        return TeamResponse.from(team)
+    }
+
+    fun create(request: CreateTeamRequest): TeamResponse {
+        val teamId = UUID.randomUUID()
+        val players = request.players.map { it.toPlayer(teamId) }
+        val team = Team(
+            id = teamId,
+            name = request.name,
+            players = players,
+        )
+        teamService.create(team)
+        return TeamResponse.from(team)
+    }
+
+    fun update(id: UUID, request: CreateTeamRequest): TeamResponse? {
+        val existingTeam = teamService.get(id) ?: return null
+        val players = request.players.map { it.toPlayer(id) }
+        val updatedTeam = existingTeam.copy(
+            name = request.name,
+            players = players,
+        )
+        teamService.delete(id)
+        teamService.create(updatedTeam)
+        return TeamResponse.from(updatedTeam)
+    }
+
+    fun delete(id: UUID): Boolean {
+        if (teamService.get(id) == null) return false
+        teamService.delete(id)
+        return true
+    }
+
+    fun addPlayer(teamId: UUID, request: CreatePlayerRequest): TeamResponse? {
+        val team = teamService.get(teamId) ?: return null
+        val newPlayer = request.toPlayer(teamId)
+        val updatedTeam = team.copy(players = team.players + newPlayer)
+        teamService.delete(teamId)
+        teamService.create(updatedTeam)
+        return TeamResponse.from(updatedTeam)
+    }
+
+    fun removePlayer(teamId: UUID, playerId: UUID): TeamResponse? {
+        val team = teamService.get(teamId) ?: return null
+        if (!team.hasPlayer(playerId)) return null
+        val updatedTeam = team.copy(players = team.players.filter { it.id != playerId })
+        teamService.delete(teamId)
+        teamService.create(updatedTeam)
+        return TeamResponse.from(updatedTeam)
+    }
+
+    private fun CreatePlayerRequest.toPlayer(teamId: UUID) = Player(
+        id = UUID.randomUUID(),
+        teamId = teamId,
+        number = number,
+        firstName = firstName,
+        lastName = lastName,
+    )
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/factory/EventFactory.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/factory/EventFactory.kt
@@ -1,0 +1,127 @@
+package com.github.mihanizzm.ultistats.factory
+
+import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.model.events.*
+import org.springframework.stereotype.Component
+
+@Component
+class EventFactory {
+    fun createFromRequest(request: CreateEventRequest): Event? {
+        return when (request.type) {
+            EventType.PASS -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                PassEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.GOAL -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                GoalEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.DROP -> {
+                if (request.playerId == null) return null
+                DropEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.PULL -> {
+                if (request.playerId == null) return null
+                PullEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.BRICK -> {
+                if (request.playerId == null) return null
+                BrickEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.TURNOVER -> {
+                if (request.playerId == null) return null
+                TurnoverEvent(
+                    player = request.playerId,
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.BLOCK_MARKER -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                BlockMarkerEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.BLOCK_FIELD -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                BlockFieldEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.INTERCEPTION -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                InterceptionEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.CALLAHAN -> {
+                if (request.playerId == null || request.toPlayerId == null || request.toTeamId == null) return null
+                CallahanEvent(
+                    fromPlayer = request.playerId,
+                    toPlayer = request.toPlayerId,
+                    fromTeam = request.teamId,
+                    toTeam = request.toTeamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.TIMEOUT_START -> {
+                TimeoutStartEvent(
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.TIMEOUT_END -> {
+                TimeoutEndEvent(
+                    team = request.teamId,
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.HALFTIME_START -> {
+                HalftimeStartEvent(
+                    realTimestamp = request.timestamp,
+                )
+            }
+            EventType.HALFTIME_END -> {
+                HalftimeEndEvent(
+                    realTimestamp = request.timestamp,
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
@@ -1,0 +1,228 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.model.events.EventType
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.time.Instant
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Suppress("NonAsciiCharacters")
+class EventControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var matchService: MatchService
+
+    @Autowired
+    lateinit var teamService: TeamService
+
+    private lateinit var team1: Team
+    private lateinit var team2: Team
+    private lateinit var match: Match
+
+    @BeforeEach
+    fun setup() {
+        matchService.getAll().forEach { matchService.delete(it.id) }
+        teamService.getAll().forEach { teamService.delete(it.id) }
+
+        team1 = createTestTeam("Команда 1")
+        team2 = createTestTeam("Команда 2")
+        match = createTestMatch(team1, team2)
+    }
+
+    @Test
+    fun `Создание события TURNOVER возвращает diskHolderId`() {
+        val player = team1.players.first()
+        val request = CreateEventRequest(
+            type = EventType.TURNOVER,
+            timestamp = Instant.now(),
+            teamId = team1.id,
+            playerId = player.id,
+        )
+
+        mockMvc.perform(
+            post("/api/matches/${match.id}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.diskHolderId").value(player.id.toString()))
+    }
+
+    @Test
+    fun `Создание события PASS обновляет diskHolderId`() {
+        val player1 = team1.players[0]
+        val player2 = team1.players[1]
+
+        // Сначала подбор диска
+        val turnoverRequest = CreateEventRequest(
+            type = EventType.TURNOVER,
+            timestamp = Instant.now(),
+            teamId = team1.id,
+            playerId = player1.id,
+        )
+        mockMvc.perform(
+            post("/api/matches/${match.id}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(turnoverRequest))
+        )
+
+        // Затем пас
+        val passRequest = CreateEventRequest(
+            type = EventType.PASS,
+            timestamp = Instant.now(),
+            teamId = team1.id,
+            playerId = player1.id,
+            toTeamId = team1.id,
+            toPlayerId = player2.id,
+        )
+
+        mockMvc.perform(
+            post("/api/matches/${match.id}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(passRequest))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.diskHolderId").value(player2.id.toString()))
+    }
+
+    @Test
+    fun `Создание события GOAL сбрасывает diskHolderId`() {
+        val player1 = team1.players[0]
+        val player2 = team1.players[1]
+
+        // Подбор
+        createEvent(EventType.TURNOVER, team1.id, player1.id!!)
+
+        // Гол
+        val goalRequest = CreateEventRequest(
+            type = EventType.GOAL,
+            timestamp = Instant.now(),
+            teamId = team1.id,
+            playerId = player1.id,
+            toTeamId = team1.id,
+            toPlayerId = player2.id,
+        )
+
+        mockMvc.perform(
+            post("/api/matches/${match.id}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(goalRequest))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.diskHolderId").doesNotExist())
+    }
+
+    @Test
+    fun `Получение событий матча возвращает список`() {
+        val player = team1.players.first()
+        createEvent(EventType.TURNOVER, team1.id, player.id!!)
+
+        mockMvc.perform(get("/api/matches/${match.id}/events"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `Удаление события пересчитывает diskHolderId`() {
+        val player1 = team1.players[0]
+        val player2 = team1.players[1]
+
+        // Подбор
+        createEvent(EventType.TURNOVER, team1.id, player1.id!!)
+
+        // Пас
+        val passRequest = CreateEventRequest(
+            type = EventType.PASS,
+            timestamp = Instant.now(),
+            teamId = team1.id,
+            playerId = player1.id,
+            toTeamId = team1.id,
+            toPlayerId = player2.id,
+        )
+        mockMvc.perform(
+            post("/api/matches/${match.id}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(passRequest))
+        )
+
+        // Удаляем пас (индекс 1)
+        mockMvc.perform(delete("/api/matches/${match.id}/events/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.diskHolderId").value(player1.id.toString()))
+    }
+
+    @Test
+    fun `Создание события для несуществующего матча возвращает 404`() {
+        val request = CreateEventRequest(
+            type = EventType.PULL,
+            timestamp = Instant.now(),
+            teamId = team1.id,
+            playerId = team1.players.first().id,
+        )
+
+        mockMvc.perform(
+            post("/api/matches/${UUID.randomUUID()}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isNotFound)
+    }
+
+    private fun createEvent(type: EventType, teamId: UUID, playerId: UUID) {
+        val request = CreateEventRequest(
+            type = type,
+            timestamp = Instant.now(),
+            teamId = teamId,
+            playerId = playerId,
+        )
+        mockMvc.perform(
+            post("/api/matches/${match.id}/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+    }
+
+    private fun createTestTeam(name: String): Team {
+        val teamId = UUID.randomUUID()
+        val team = Team(
+            id = teamId,
+            name = name,
+            players = listOf(
+                Player(UUID.randomUUID(), teamId, 1, "Игрок", "Один"),
+                Player(UUID.randomUUID(), teamId, 2, "Игрок", "Два"),
+            )
+        )
+        teamService.create(team)
+        return team
+    }
+
+    private fun createTestMatch(team1: Team, team2: Team): Match {
+        val match = Match(
+            id = UUID.randomUUID(),
+            teams = listOf(team1, team2),
+        )
+        matchService.create(match)
+        return match
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
@@ -1,0 +1,132 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Suppress("NonAsciiCharacters")
+class MatchControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var matchService: MatchService
+
+    @Autowired
+    lateinit var teamService: TeamService
+
+    @BeforeEach
+    fun setup() {
+        matchService.getAll().forEach { matchService.delete(it.id) }
+        teamService.getAll().forEach { teamService.delete(it.id) }
+    }
+
+    @Test
+    fun `Создание матча возвращает 201`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+        val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
+
+        mockMvc.perform(
+            post("/api/matches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.teams.length()").value(2))
+            .andExpect(jsonPath("$.eventCount").value(0))
+            .andExpect(jsonPath("$.diskHolderId").doesNotExist())
+    }
+
+    @Test
+    fun `Создание матча с несуществующей командой возвращает 400`() {
+        val team1 = createTestTeam("Команда 1")
+        val request = CreateMatchRequest(teamIds = listOf(team1.id, UUID.randomUUID()))
+
+        mockMvc.perform(
+            post("/api/matches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `Получение матча по ID возвращает 200`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+        val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
+
+        val result = mockMvc.perform(
+            post("/api/matches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        ).andReturn()
+
+        val matchId = objectMapper.readTree(result.response.contentAsString).get("id").asText()
+
+        mockMvc.perform(get("/api/matches/$matchId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(matchId))
+    }
+
+    @Test
+    fun `Получение несуществующего матча возвращает 404`() {
+        mockMvc.perform(get("/api/matches/${UUID.randomUUID()}"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Удаление матча возвращает 204`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+        val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
+
+        val result = mockMvc.perform(
+            post("/api/matches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        ).andReturn()
+
+        val matchId = objectMapper.readTree(result.response.contentAsString).get("id").asText()
+
+        mockMvc.perform(delete("/api/matches/$matchId"))
+            .andExpect(status().isNoContent)
+
+        mockMvc.perform(get("/api/matches/$matchId"))
+            .andExpect(status().isNotFound)
+    }
+
+    private fun createTestTeam(name: String): Team {
+        val teamId = UUID.randomUUID()
+        val team = Team(
+            id = teamId,
+            name = name,
+            players = listOf(
+                Player(UUID.randomUUID(), teamId, 1, "Игрок", "Один"),
+                Player(UUID.randomUUID(), teamId, 2, "Игрок", "Два"),
+            )
+        )
+        teamService.create(team)
+        return team
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -1,0 +1,113 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.model.events.PassEvent
+import com.github.mihanizzm.ultistats.model.events.TurnoverEvent
+import com.github.mihanizzm.ultistats.service.EventService
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.time.Instant
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Suppress("NonAsciiCharacters")
+class StatisticsControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var matchService: MatchService
+
+    @Autowired
+    lateinit var teamService: TeamService
+
+    @Autowired
+    lateinit var eventService: EventService
+
+    private lateinit var team1: Team
+    private lateinit var team2: Team
+    private lateinit var match: Match
+
+    @BeforeEach
+    fun setup() {
+        matchService.getAll().forEach { matchService.delete(it.id) }
+        teamService.getAll().forEach { teamService.delete(it.id) }
+
+        team1 = createTestTeam("Команда 1")
+        team2 = createTestTeam("Команда 2")
+        match = createTestMatch(team1, team2)
+    }
+
+    @Test
+    fun `Получение статистики пустого матча возвращает 200`() {
+        mockMvc.perform(get("/api/matches/${match.id}/statistics"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.playerStatistics").isArray)
+            .andExpect(jsonPath("$.teamStatistics").isArray)
+    }
+
+    @Test
+    fun `Получение статистики несуществующего матча возвращает 404`() {
+        mockMvc.perform(get("/api/matches/${UUID.randomUUID()}/statistics"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Статистика учитывает события матча`() {
+        val player1 = team1.players[0]
+        val player2 = team1.players[1]
+
+        // Добавляем события: подбор и пас
+        eventService.create(
+            TurnoverEvent(player1.id!!, team1.id, Instant.now()),
+            match.id
+        )
+        eventService.create(
+            PassEvent(player1.id!!, player2.id!!, team1.id, team1.id, Instant.now()),
+            match.id
+        )
+
+        mockMvc.perform(get("/api/matches/${match.id}/statistics"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.teamStatistics[?(@.teamId=='${team1.id}')].attack.allPasses").value(1))
+            .andExpect(jsonPath("$.teamStatistics[?(@.teamId=='${team1.id}')].attack.completePasses").value(1))
+    }
+
+    private fun createTestTeam(name: String): Team {
+        val teamId = UUID.randomUUID()
+        val team = Team(
+            id = teamId,
+            name = name,
+            players = listOf(
+                Player(UUID.randomUUID(), teamId, 1, "Игрок", "Один"),
+                Player(UUID.randomUUID(), teamId, 2, "Игрок", "Два"),
+            )
+        )
+        teamService.create(team)
+        return team
+    }
+
+    private fun createTestMatch(team1: Team, team2: Team): Match {
+        val match = Match(
+            id = UUID.randomUUID(),
+            teams = listOf(team1, team2),
+        )
+        matchService.create(match)
+        return match
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
@@ -1,0 +1,136 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Suppress("NonAsciiCharacters")
+class TeamControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var teamService: TeamService
+
+    @BeforeEach
+    fun setup() {
+        teamService.getAll().forEach { teamService.delete(it.id) }
+    }
+
+    @Test
+    fun `Создание команды возвращает 201`() {
+        val request = CreateTeamRequest(
+            name = "Test Team",
+            players = listOf(
+                CreatePlayerRequest(number = 10, firstName = "Иван", lastName = "Иванов"),
+            )
+        )
+
+        mockMvc.perform(
+            post("/api/teams")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.name").value("Test Team"))
+            .andExpect(jsonPath("$.players[0].firstName").value("Иван"))
+            .andExpect(jsonPath("$.id").exists())
+    }
+
+    @Test
+    fun `Получение команды по ID возвращает 200`() {
+        val team = createTestTeam()
+
+        mockMvc.perform(get("/api/teams/${team.id}"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.name").value(team.name))
+    }
+
+    @Test
+    fun `Получение несуществующей команды возвращает 404`() {
+        mockMvc.perform(get("/api/teams/${UUID.randomUUID()}"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Получение всех команд возвращает список`() {
+        createTestTeam("Team 1")
+        createTestTeam("Team 2")
+
+        mockMvc.perform(get("/api/teams"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(2))
+    }
+
+    @Test
+    fun `Удаление команды возвращает 204`() {
+        val team = createTestTeam()
+
+        mockMvc.perform(delete("/api/teams/${team.id}"))
+            .andExpect(status().isNoContent)
+
+        mockMvc.perform(get("/api/teams/${team.id}"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Добавление игрока в команду возвращает 201`() {
+        val team = createTestTeam()
+        val request = CreatePlayerRequest(number = 99, firstName = "Новый", lastName = "Игрок")
+
+        mockMvc.perform(
+            post("/api/teams/${team.id}/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.players.length()").value(2))
+    }
+
+    @Test
+    fun `Удаление игрока из команды возвращает 200`() {
+        val team = createTestTeam()
+        val playerId = team.players.first().id
+
+        mockMvc.perform(delete("/api/teams/${team.id}/players/$playerId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.players.length()").value(0))
+    }
+
+    private fun createTestTeam(name: String = "Test Team"): Team {
+        val teamId = UUID.randomUUID()
+        val team = Team(
+            id = teamId,
+            name = name,
+            players = listOf(
+                Player(
+                    id = UUID.randomUUID(),
+                    teamId = teamId,
+                    number = 10,
+                    firstName = "Тест",
+                    lastName = "Игрок",
+                )
+            )
+        )
+        teamService.create(team)
+        return team
+    }
+}


### PR DESCRIPTION
## Summary
- Добавлен Swagger UI (springdoc-openapi) для тестирования API
- Реализованы контроллеры для всех основных сущностей
- Написаны интеграционные тесты

## Контроллеры

### TeamController (`/api/teams`)
- `GET /api/teams` — список команд
- `GET /api/teams/{id}` — получить команду
- `POST /api/teams` — создать команду
- `PUT /api/teams/{id}` — обновить команду
- `DELETE /api/teams/{id}` — удалить команду
- `POST /api/teams/{id}/players` — добавить игрока
- `DELETE /api/teams/{teamId}/players/{playerId}` — удалить игрока

### MatchController (`/api/matches`)
- `GET /api/matches` — список матчей
- `GET /api/matches/{id}` — получить матч
- `POST /api/matches` — создать матч
- `DELETE /api/matches/{id}` — удалить матч

### EventController (`/api/matches/{matchId}/events`)
- `GET` — список событий
- `POST` — создать событие (возвращает `diskHolderId`)
- `PUT /{index}` — изменить событие
- `DELETE /{index}` — удалить событие

### StatisticsController (`/api/matches/{matchId}/statistics`)
- `GET` — получить статистику матча

## Swagger UI
После запуска приложения доступен по адресу: http://localhost:8080/swagger-ui.html

## Test plan
- [x] Интеграционные тесты TeamController (7 тестов)
- [x] Интеграционные тесты MatchController (5 тестов)
- [x] Интеграционные тесты EventController (6 тестов)
- [x] Все существующие тесты проходят

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)