### PR TITLE
#24: Расширить модель матча и добавить версионирование API

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/matches/{matchId}/events")
+@RequestMapping("/api/v1/matches/{matchId}/events")
 @Tag(name = "Events", description = "Управление событиями матча")
 class EventController(
     private val eventFacade: EventFacade,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -1,6 +1,7 @@
 package com.github.mihanizzm.ultistats.controller
 
 import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
 import com.github.mihanizzm.ultistats.facade.MatchFacade
 import io.swagger.v3.oas.annotations.Operation
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/matches")
+@RequestMapping("/api/v1/matches")
 @Tag(name = "Matches", description = "Управление матчами")
 class MatchController(
     private val matchFacade: MatchFacade,
@@ -40,4 +41,24 @@ class MatchController(
     fun delete(@PathVariable id: UUID): ResponseEntity<Unit> =
         if (matchFacade.delete(id)) ResponseEntity.noContent().build()
         else ResponseEntity.notFound().build()
+
+    @PostMapping("/{id}/start")
+    @Operation(summary = "Начать матч")
+    fun startMatch(
+        @PathVariable id: UUID,
+        @RequestBody request: MatchTimestampRequest,
+    ): ResponseEntity<MatchResponse> =
+        matchFacade.startMatch(id, request)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.badRequest().build()
+
+    @PostMapping("/{id}/end")
+    @Operation(summary = "Завершить матч")
+    fun endMatch(
+        @PathVariable id: UUID,
+        @RequestBody request: MatchTimestampRequest,
+    ): ResponseEntity<MatchResponse> =
+        matchFacade.endMatch(id, request)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.badRequest().build()
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/players")
+@RequestMapping("/api/v1/players")
 @Tag(name = "Players", description = "Управление игроками")
 class PlayerController(
     private val playerFacade: PlayerFacade,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/matches/{matchId}/statistics")
+@RequestMapping("/api/v1/matches/{matchId}/statistics")
 @Tag(name = "Statistics", description = "Получение статистики матча")
 class StatisticsController(
     private val statisticsService: StatisticsService,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/teams")
+@RequestMapping("/api/v1/teams")
 @Tag(name = "Teams", description = "Управление командами")
 class TeamController(
     private val teamFacade: TeamFacade,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateMatchRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateMatchRequest.kt
@@ -1,7 +1,9 @@
 package com.github.mihanizzm.ultistats.dto.request
 
+import java.time.Instant
 import java.util.UUID
 
 data class CreateMatchRequest(
     val teamIds: List<UUID>,
+    val plannedStartTimestamp: Instant? = null,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/MatchTimestampRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/MatchTimestampRequest.kt
@@ -1,0 +1,7 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+import java.time.Instant
+
+data class MatchTimestampRequest(
+    val timestamp: Instant,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
@@ -2,6 +2,7 @@ package com.github.mihanizzm.ultistats.dto.response
 
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.Player
+import java.time.Instant
 import java.util.UUID
 
 data class MatchResponse(
@@ -9,6 +10,9 @@ data class MatchResponse(
     val teams: List<TeamResponse>,
     val eventCount: Int,
     val diskHolderId: UUID?,
+    val plannedStartTimestamp: Instant?,
+    val startedAt: Instant?,
+    val endedAt: Instant?,
 ) {
     companion object {
         fun from(match: Match, playersByTeamId: Map<UUID, List<Player>>) = MatchResponse(
@@ -18,6 +22,9 @@ data class MatchResponse(
             },
             eventCount = match.events.size,
             diskHolderId = match.diskHolderId,
+            plannedStartTimestamp = match.plannedStartTimestamp,
+            startedAt = match.startedAt,
+            endedAt = match.endedAt,
         )
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
@@ -1,6 +1,7 @@
 package com.github.mihanizzm.ultistats.facade
 
 import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.Player
@@ -34,6 +35,7 @@ class MatchFacade(
         val match = Match(
             id = UUID.randomUUID(),
             teams = teams,
+            plannedStartTimestamp = request.plannedStartTimestamp,
         )
         matchService.create(match)
         return MatchResponse.from(match, getPlayersByTeamId(match))
@@ -43,6 +45,22 @@ class MatchFacade(
         if (matchService.get(id) == null) return false
         matchService.delete(id)
         return true
+    }
+
+    fun startMatch(id: UUID, request: MatchTimestampRequest): MatchResponse? {
+        val match = matchService.get(id) ?: return null
+        if (!matchService.startMatch(id, request.timestamp)) {
+            return null
+        }
+        return MatchResponse.from(match, getPlayersByTeamId(match))
+    }
+
+    fun endMatch(id: UUID, request: MatchTimestampRequest): MatchResponse? {
+        val match = matchService.get(id) ?: return null
+        if (!matchService.endMatch(id, request.timestamp)) {
+            return null
+        }
+        return MatchResponse.from(match, getPlayersByTeamId(match))
     }
 
     private fun getPlayersByTeamId(match: Match): Map<UUID, List<Player>> =

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
@@ -1,6 +1,7 @@
 package com.github.mihanizzm.ultistats.model
 
 import com.github.mihanizzm.ultistats.model.events.Event
+import java.time.Instant
 import java.util.UUID
 
 data class Match(
@@ -8,4 +9,7 @@ data class Match(
     val teams: List<Team>,
     val events: MutableList<Event> = mutableListOf(),
     var diskHolderId: UUID? = null,
+    val plannedStartTimestamp: Instant? = null,
+    var startedAt: Instant? = null,
+    var endedAt: Instant? = null,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchService.kt
@@ -1,6 +1,7 @@
 package com.github.mihanizzm.ultistats.service
 
 import com.github.mihanizzm.ultistats.model.Match
+import java.time.Instant
 import java.util.UUID
 
 interface MatchService {
@@ -18,4 +19,18 @@ interface MatchService {
      * Пересчитать владельца диска на основе списка событий матча.
      */
     fun recalculateDiskHolder(matchId: UUID)
+
+    /**
+     * Начать матч. Устанавливает startedAt в переданное время.
+     * @param timestamp время начала матча, переданное клиентом
+     * @return true если матч успешно начат, false если матч уже начат
+     */
+    fun startMatch(matchId: UUID, timestamp: Instant): Boolean
+
+    /**
+     * Завершить матч. Устанавливает endedAt в переданное время.
+     * @param timestamp время окончания матча, переданное клиентом
+     * @return true если матч успешно завершён, false если матч не начат или уже завершён
+     */
+    fun endMatch(matchId: UUID, timestamp: Instant): Boolean
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
@@ -5,6 +5,7 @@ import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.events.*
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.Instant
 import java.util.UUID
 
 @Service
@@ -28,6 +29,24 @@ class MatchServiceImpl(
     override fun recalculateDiskHolder(matchId: UUID) {
         val match = getOrThrow(matchId)
         match.diskHolderId = calculateDiskHolder(match.events)
+    }
+
+    override fun startMatch(matchId: UUID, timestamp: Instant): Boolean {
+        val match = getOrThrow(matchId)
+        if (match.startedAt != null) {
+            return false
+        }
+        match.startedAt = timestamp
+        return true
+    }
+
+    override fun endMatch(matchId: UUID, timestamp: Instant): Boolean {
+        val match = getOrThrow(matchId)
+        if (match.startedAt == null || match.endedAt != null) {
+            return false
+        }
+        match.endedAt = timestamp
+        return true
     }
 
     private fun calculateDiskHolder(events: List<Event>): UUID? {

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
@@ -72,7 +72,7 @@ class EventControllerTest {
         )
 
         mockMvc.perform(
-            post("/api/matches/${match.id}/events")
+            post("/api/v1/matches/${match.id}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
@@ -93,7 +93,7 @@ class EventControllerTest {
             playerId = player1.id,
         )
         mockMvc.perform(
-            post("/api/matches/${match.id}/events")
+            post("/api/v1/matches/${match.id}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(turnoverRequest))
         )
@@ -109,7 +109,7 @@ class EventControllerTest {
         )
 
         mockMvc.perform(
-            post("/api/matches/${match.id}/events")
+            post("/api/v1/matches/${match.id}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(passRequest))
         )
@@ -136,7 +136,7 @@ class EventControllerTest {
         )
 
         mockMvc.perform(
-            post("/api/matches/${match.id}/events")
+            post("/api/v1/matches/${match.id}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(goalRequest))
         )
@@ -149,7 +149,7 @@ class EventControllerTest {
         val player = players1.first()
         createEvent(EventType.TURNOVER, team1.id, player.id)
 
-        mockMvc.perform(get("/api/matches/${match.id}/events"))
+        mockMvc.perform(get("/api/v1/matches/${match.id}/events"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(1))
     }
@@ -172,13 +172,13 @@ class EventControllerTest {
             toPlayerId = player2.id,
         )
         mockMvc.perform(
-            post("/api/matches/${match.id}/events")
+            post("/api/v1/matches/${match.id}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(passRequest))
         )
 
         // Удаляем пас (индекс 1)
-        mockMvc.perform(delete("/api/matches/${match.id}/events/1"))
+        mockMvc.perform(delete("/api/v1/matches/${match.id}/events/1"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.diskHolderId").value(player1.id.toString()))
     }
@@ -193,7 +193,7 @@ class EventControllerTest {
         )
 
         mockMvc.perform(
-            post("/api/matches/${UUID.randomUUID()}/events")
+            post("/api/v1/matches/${UUID.randomUUID()}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
@@ -208,7 +208,7 @@ class EventControllerTest {
             playerId = playerId,
         )
         mockMvc.perform(
-            post("/api/matches/${match.id}/events")
+            post("/api/v1/matches/${match.id}/events")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
@@ -51,7 +51,7 @@ class MatchControllerTest {
         val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
 
         mockMvc.perform(
-            post("/api/matches")
+            post("/api/v1/matches")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
@@ -68,7 +68,7 @@ class MatchControllerTest {
         val request = CreateMatchRequest(teamIds = listOf(team1.id, UUID.randomUUID()))
 
         mockMvc.perform(
-            post("/api/matches")
+            post("/api/v1/matches")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
@@ -82,21 +82,21 @@ class MatchControllerTest {
         val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
 
         val result = mockMvc.perform(
-            post("/api/matches")
+            post("/api/v1/matches")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         ).andReturn()
 
         val matchId = objectMapper.readTree(result.response.contentAsString).get("id").asText()
 
-        mockMvc.perform(get("/api/matches/$matchId"))
+        mockMvc.perform(get("/api/v1/matches/$matchId"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(matchId))
     }
 
     @Test
     fun `Получение несуществующего матча возвращает 404`() {
-        mockMvc.perform(get("/api/matches/${UUID.randomUUID()}"))
+        mockMvc.perform(get("/api/v1/matches/${UUID.randomUUID()}"))
             .andExpect(status().isNotFound)
     }
 
@@ -107,17 +107,17 @@ class MatchControllerTest {
         val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
 
         val result = mockMvc.perform(
-            post("/api/matches")
+            post("/api/v1/matches")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         ).andReturn()
 
         val matchId = objectMapper.readTree(result.response.contentAsString).get("id").asText()
 
-        mockMvc.perform(delete("/api/matches/$matchId"))
+        mockMvc.perform(delete("/api/v1/matches/$matchId"))
             .andExpect(status().isNoContent)
 
-        mockMvc.perform(get("/api/matches/$matchId"))
+        mockMvc.perform(get("/api/v1/matches/$matchId"))
             .andExpect(status().isNotFound)
     }
 

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -66,7 +66,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `Получение статистики пустого матча возвращает 200`() {
-        mockMvc.perform(get("/api/matches/${match.id}/statistics"))
+        mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.playerStatistics").isArray)
             .andExpect(jsonPath("$.teamStatistics").isArray)
@@ -74,7 +74,7 @@ class StatisticsControllerTest {
 
     @Test
     fun `Получение статистики несуществующего матча возвращает 404`() {
-        mockMvc.perform(get("/api/matches/${UUID.randomUUID()}/statistics"))
+        mockMvc.perform(get("/api/v1/matches/${UUID.randomUUID()}/statistics"))
             .andExpect(status().isNotFound)
     }
 
@@ -93,7 +93,7 @@ class StatisticsControllerTest {
             match.id
         )
 
-        mockMvc.perform(get("/api/matches/${match.id}/statistics"))
+        mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.teamStatistics[?(@.teamId=='${team1.id}')].attack.allPasses").value(1))
             .andExpect(jsonPath("$.teamStatistics[?(@.teamId=='${team1.id}')].attack.completePasses").value(1))

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
@@ -56,7 +56,7 @@ class TeamControllerTest {
         )
 
         mockMvc.perform(
-            post("/api/teams")
+            post("/api/v1/teams")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
@@ -70,14 +70,14 @@ class TeamControllerTest {
     fun `Получение команды по ID возвращает 200`() {
         val (team, _) = createTestTeam()
 
-        mockMvc.perform(get("/api/teams/${team.id}"))
+        mockMvc.perform(get("/api/v1/teams/${team.id}"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.name").value(team.name))
     }
 
     @Test
     fun `Получение несуществующей команды возвращает 404`() {
-        mockMvc.perform(get("/api/teams/${UUID.randomUUID()}"))
+        mockMvc.perform(get("/api/v1/teams/${UUID.randomUUID()}"))
             .andExpect(status().isNotFound)
     }
 
@@ -86,7 +86,7 @@ class TeamControllerTest {
         createTestTeam("Team 1")
         createTestTeam("Team 2")
 
-        mockMvc.perform(get("/api/teams"))
+        mockMvc.perform(get("/api/v1/teams"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(2))
     }
@@ -95,10 +95,10 @@ class TeamControllerTest {
     fun `Удаление команды возвращает 204`() {
         val (team, _) = createTestTeam()
 
-        mockMvc.perform(delete("/api/teams/${team.id}"))
+        mockMvc.perform(delete("/api/v1/teams/${team.id}"))
             .andExpect(status().isNoContent)
 
-        mockMvc.perform(get("/api/teams/${team.id}"))
+        mockMvc.perform(get("/api/v1/teams/${team.id}"))
             .andExpect(status().isNotFound)
     }
 
@@ -115,7 +115,7 @@ class TeamControllerTest {
         )
         playerService.create(newPlayer)
 
-        mockMvc.perform(post("/api/teams/${team.id}/players/${newPlayer.id}"))
+        mockMvc.perform(post("/api/v1/teams/${team.id}/players/${newPlayer.id}"))
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.players.length()").value(players.size + 1))
     }
@@ -125,7 +125,7 @@ class TeamControllerTest {
         val (team, players) = createTestTeam()
         val playerId = players.first().id
 
-        mockMvc.perform(delete("/api/teams/${team.id}/players/$playerId"))
+        mockMvc.perform(delete("/api/v1/teams/${team.id}/players/$playerId"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.players.length()").value(players.size - 1))
     }


### PR DESCRIPTION
## Summary

- Добавлены временные поля в `Match`: `plannedStartTimestamp`, `startedAt`, `endedAt`
- Добавлены API эндпоинты для старта/завершения матча: `POST /api/v1/matches/{id}/start` и `POST /api/v1/matches/{id}/end`
- Timestamp передаётся клиентом через `MatchTimestampRequest` (консистентно с игровыми событиями)
- Все эндпоинты перенесены с `/api/...` на `/api/v1/...`

## Новые эндпоинты

```
POST /api/v1/matches/{id}/start
POST /api/v1/matches/{id}/end
```

Тело запроса:
```json
{
  "timestamp": "2025-02-26T15:00:00Z"
}
```

## Изменения в DTO

**CreateMatchRequest:**
- `+ plannedStartTimestamp: Instant?`

**MatchResponse:**
- `+ plannedStartTimestamp: Instant?`
- `+ startedAt: Instant?`
- `+ endedAt: Instant?`

## Test plan

- [x] Все существующие тесты проходят
- [ ] Проверить создание матча с plannedStartTimestamp
- [ ] Проверить start/end матча через Swagger

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)