### PR TITLE
#26: Пагинация, фильтрация и сортировка

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -27,24 +27,37 @@ class MatchController(
     @Operation(summary = "Получить матчи с пагинацией, фильтрацией и сортировкой")
     fun getAll(
         @Parameter(description = "Номер страницы (начиная с 0)")
-        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "0")
+        page: Int,
+
         @Parameter(description = "Размер страницы")
-        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(defaultValue = "20")
+        size: Int,
+
         @Parameter(description = "Фильтр по ID команды-участника")
-        @RequestParam(required = false) teamId: UUID?,
+        @RequestParam(required = false)
+        teamId: UUID?,
+
         @Parameter(description = "Фильтр по статусу матча (PLANNED, IN_PROGRESS, FINISHED)")
-        @RequestParam(required = false) status: MatchStatus?,
+        @RequestParam(required = false)
+        status: MatchStatus?,
+
         @Parameter(description = "Фильтр по дате начиная с (ISO 8601)")
-        @RequestParam(required = false) dateFrom: Instant?,
+        @RequestParam(required = false)
+        dateFrom: Instant?,
+
         @Parameter(description = "Фильтр по дате до (ISO 8601)")
-        @RequestParam(required = false) dateTo: Instant?,
+        @RequestParam(required = false)
+        dateTo: Instant?,
+
         @Parameter(
             description = "Сортировка. Формат: field:direction. " +
                 "Доступные поля: plannedStartTimestamp, startedAt, endedAt, status. " +
                 "По умолчанию: plannedStartTimestamp:asc",
             example = "plannedStartTimestamp:asc"
         )
-        @RequestParam(required = false) sort: String?,
+        @RequestParam(required = false)
+        sort: String?,
     ): PageResponse<MatchResponse> {
         val filter = MatchFilterRequest(
             teamId = teamId,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -1,14 +1,20 @@
 package com.github.mihanizzm.ultistats.controller
 
+import com.github.mihanizzm.ultistats.dto.common.PageResponse
+import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
 import com.github.mihanizzm.ultistats.facade.MatchFacade
+import com.github.mihanizzm.ultistats.model.MatchStatus
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.time.Instant
 import java.util.UUID
 
 @RestController
@@ -18,8 +24,37 @@ class MatchController(
     private val matchFacade: MatchFacade,
 ) {
     @GetMapping
-    @Operation(summary = "Получить все матчи")
-    fun getAll(): List<MatchResponse> = matchFacade.getAll()
+    @Operation(summary = "Получить матчи с пагинацией, фильтрацией и сортировкой")
+    fun getAll(
+        @Parameter(description = "Номер страницы (начиная с 0)")
+        @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "Размер страницы")
+        @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "Фильтр по ID команды-участника")
+        @RequestParam(required = false) teamId: UUID?,
+        @Parameter(description = "Фильтр по статусу матча (PLANNED, IN_PROGRESS, FINISHED)")
+        @RequestParam(required = false) status: MatchStatus?,
+        @Parameter(description = "Фильтр по дате начиная с (ISO 8601)")
+        @RequestParam(required = false) dateFrom: Instant?,
+        @Parameter(description = "Фильтр по дате до (ISO 8601)")
+        @RequestParam(required = false) dateTo: Instant?,
+        @Parameter(
+            description = "Сортировка. Формат: field:direction. " +
+                "Доступные поля: plannedStartTimestamp, startedAt, endedAt, status. " +
+                "По умолчанию: plannedStartTimestamp:asc",
+            example = "plannedStartTimestamp:asc"
+        )
+        @RequestParam(required = false) sort: String?,
+    ): PageResponse<MatchResponse> {
+        val filter = MatchFilterRequest(
+            teamId = teamId,
+            status = status,
+            dateFrom = dateFrom,
+            dateTo = dateTo,
+        )
+        val sortParam = sort?.let { SortParam.parse(it) } ?: MatchFacade.DEFAULT_SORT
+        return matchFacade.getAllPaged(page, size, filter, sortParam)
+    }
 
     @GetMapping("/{id}")
     @Operation(summary = "Получить матч по ID")

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
@@ -1,9 +1,13 @@
 package com.github.mihanizzm.ultistats.controller
 
+import com.github.mihanizzm.ultistats.dto.common.PageResponse
+import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.dto.response.PlayerResponse
 import com.github.mihanizzm.ultistats.facade.PlayerFacade
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -17,8 +21,28 @@ class PlayerController(
     private val playerFacade: PlayerFacade,
 ) {
     @GetMapping
-    @Operation(summary = "Получить всех игроков")
-    fun getAll(): List<PlayerResponse> = playerFacade.getAll()
+    @Operation(summary = "Получить игроков с пагинацией, фильтрацией и сортировкой")
+    fun getAll(
+        @Parameter(description = "Номер страницы (начиная с 0)")
+        @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "Размер страницы")
+        @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "Фильтр по имени (частичное совпадение)")
+        @RequestParam(required = false) name: String?,
+        @Parameter(description = "Фильтр по ID команды")
+        @RequestParam(required = false) teamId: UUID?,
+        @Parameter(
+            description = "Сортировка. Формат: field:direction. " +
+                "Доступные поля: lastName, firstName, number, teamId. " +
+                "По умолчанию: lastName:asc",
+            example = "lastName:asc"
+        )
+        @RequestParam(required = false) sort: String?,
+    ): PageResponse<PlayerResponse> {
+        val filter = PlayerFilterRequest(name = name, teamId = teamId)
+        val sortParam = sort?.let { SortParam.parse(it) } ?: PlayerFacade.DEFAULT_SORT
+        return playerFacade.getAllPaged(page, size, filter, sortParam)
+    }
 
     @GetMapping("/{id}")
     @Operation(summary = "Получить игрока по ID")

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
@@ -24,20 +24,29 @@ class PlayerController(
     @Operation(summary = "Получить игроков с пагинацией, фильтрацией и сортировкой")
     fun getAll(
         @Parameter(description = "Номер страницы (начиная с 0)")
-        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "0")
+        page: Int,
+
         @Parameter(description = "Размер страницы")
-        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(defaultValue = "20")
+        size: Int,
+
         @Parameter(description = "Фильтр по имени (частичное совпадение)")
-        @RequestParam(required = false) name: String?,
+        @RequestParam(required = false)
+        name: String?,
+
         @Parameter(description = "Фильтр по ID команды")
-        @RequestParam(required = false) teamId: UUID?,
+        @RequestParam(required = false)
+        teamId: UUID?,
+
         @Parameter(
             description = "Сортировка. Формат: field:direction. " +
                 "Доступные поля: lastName, firstName, number, teamId. " +
                 "По умолчанию: lastName:asc",
             example = "lastName:asc"
         )
-        @RequestParam(required = false) sort: String?,
+        @RequestParam(required = false)
+        sort: String?,
     ): PageResponse<PlayerResponse> {
         val filter = PlayerFilterRequest(name = name, teamId = teamId)
         val sortParam = sort?.let { SortParam.parse(it) } ?: PlayerFacade.DEFAULT_SORT

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -24,17 +24,24 @@ class TeamController(
     @Operation(summary = "Получить команды с пагинацией, фильтрацией и сортировкой")
     fun getAll(
         @Parameter(description = "Номер страницы (начиная с 0)")
-        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "0")
+        page: Int,
+
         @Parameter(description = "Размер страницы")
-        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(defaultValue = "20")
+        size: Int,
+
         @Parameter(description = "Фильтр по названию (частичное совпадение)")
-        @RequestParam(required = false) name: String?,
+        @RequestParam(required = false)
+        name: String?,
+
         @Parameter(
             description = "Сортировка. Формат: field:direction. " +
                 "Доступные поля: name. По умолчанию: name:asc",
             example = "name:asc"
         )
-        @RequestParam(required = false) sort: String?,
+        @RequestParam(required = false)
+        sort: String?,
     ): PageResponse<TeamResponse> {
         val filter = TeamFilterRequest(name = name)
         val sortParam = sort?.let { SortParam.parse(it) } ?: TeamFacade.DEFAULT_SORT

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -1,9 +1,13 @@
 package com.github.mihanizzm.ultistats.controller
 
+import com.github.mihanizzm.ultistats.dto.common.PageResponse
+import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.dto.response.TeamResponse
 import com.github.mihanizzm.ultistats.facade.TeamFacade
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -17,8 +21,25 @@ class TeamController(
     private val teamFacade: TeamFacade,
 ) {
     @GetMapping
-    @Operation(summary = "Получить все команды")
-    fun getAll(): List<TeamResponse> = teamFacade.getAll()
+    @Operation(summary = "Получить команды с пагинацией, фильтрацией и сортировкой")
+    fun getAll(
+        @Parameter(description = "Номер страницы (начиная с 0)")
+        @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "Размер страницы")
+        @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "Фильтр по названию (частичное совпадение)")
+        @RequestParam(required = false) name: String?,
+        @Parameter(
+            description = "Сортировка. Формат: field:direction. " +
+                "Доступные поля: name. По умолчанию: name:asc",
+            example = "name:asc"
+        )
+        @RequestParam(required = false) sort: String?,
+    ): PageResponse<TeamResponse> {
+        val filter = TeamFilterRequest(name = name)
+        val sortParam = sort?.let { SortParam.parse(it) } ?: TeamFacade.DEFAULT_SORT
+        return teamFacade.getAllPaged(page, size, filter, sortParam)
+    }
 
     @GetMapping("/{id}")
     @Operation(summary = "Получить команду по ID")

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/common/PageResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/common/PageResponse.kt
@@ -1,0 +1,31 @@
+package com.github.mihanizzm.ultistats.dto.common
+
+data class PageResponse<T>(
+    val content: List<T>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val size: Int,
+) {
+    companion object {
+        fun <T> of(
+            content: List<T>,
+            totalElements: Long,
+            page: Int,
+            size: Int,
+        ): PageResponse<T> {
+            val totalPages = if (size > 0) {
+                ((totalElements + size - 1) / size).toInt()
+            } else {
+                0
+            }
+            return PageResponse(
+                content = content,
+                totalElements = totalElements,
+                totalPages = totalPages,
+                currentPage = page,
+                size = size,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/common/SortParam.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/common/SortParam.kt
@@ -1,0 +1,35 @@
+package com.github.mihanizzm.ultistats.dto.common
+
+data class SortParam(
+    val field: String,
+    val direction: SortDirection = SortDirection.ASC,
+) {
+    companion object {
+        /**
+         * Парсит строку вида "lastName:desc" или "lastName" (asc по умолчанию).
+         */
+        fun parse(param: String): SortParam {
+            val parts = param.split(":")
+            val field = parts[0].trim()
+            val direction = if (parts.size > 1) {
+                SortDirection.fromString(parts[1].trim())
+            } else {
+                SortDirection.ASC
+            }
+            return SortParam(field, direction)
+        }
+    }
+}
+
+enum class SortDirection {
+    ASC,
+    DESC;
+
+    companion object {
+        fun fromString(value: String): SortDirection =
+            when (value.lowercase()) {
+                "desc" -> DESC
+                else -> ASC
+            }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/MatchFilterRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/MatchFilterRequest.kt
@@ -1,0 +1,12 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+import com.github.mihanizzm.ultistats.model.MatchStatus
+import java.time.Instant
+import java.util.UUID
+
+data class MatchFilterRequest(
+    val teamId: UUID? = null,
+    val status: MatchStatus? = null,
+    val dateFrom: Instant? = null,
+    val dateTo: Instant? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/PlayerFilterRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/PlayerFilterRequest.kt
@@ -1,0 +1,8 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+import java.util.UUID
+
+data class PlayerFilterRequest(
+    val name: String? = null,
+    val teamId: UUID? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/TeamFilterRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/TeamFilterRequest.kt
@@ -1,0 +1,5 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+data class TeamFilterRequest(
+    val name: String? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
@@ -1,6 +1,7 @@
 package com.github.mihanizzm.ultistats.dto.response
 
 import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.MatchStatus
 import com.github.mihanizzm.ultistats.model.Player
 import java.time.Instant
 import java.util.UUID
@@ -13,6 +14,7 @@ data class MatchResponse(
     val plannedStartTimestamp: Instant?,
     val startedAt: Instant?,
     val endedAt: Instant?,
+    val status: MatchStatus,
 ) {
     companion object {
         fun from(match: Match, playersByTeamId: Map<UUID, List<Player>>) = MatchResponse(
@@ -25,6 +27,7 @@ data class MatchResponse(
             plannedStartTimestamp = match.plannedStartTimestamp,
             startedAt = match.startedAt,
             endedAt = match.endedAt,
+            status = match.status,
         )
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
@@ -1,6 +1,9 @@
 package com.github.mihanizzm.ultistats.facade
 
+import com.github.mihanizzm.ultistats.dto.common.PageResponse
+import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
 import com.github.mihanizzm.ultistats.model.Match
@@ -8,6 +11,7 @@ import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -17,10 +21,42 @@ class MatchFacade(
     private val teamService: TeamService,
     private val playerService: PlayerService,
 ) {
+    companion object {
+        val DEFAULT_SORT = SortParam("plannedStartTimestamp")
+
+        val SORT_FIELD_EXTRACTORS: Map<String, (Match) -> Comparable<*>?> = mapOf(
+            "plannedStartTimestamp" to { it.plannedStartTimestamp },
+            "startedAt" to { it.startedAt },
+            "endedAt" to { it.endedAt },
+            "status" to { it.status.name },
+        )
+    }
+
     fun getAll(): List<MatchResponse> =
         matchService.getAll().map { match ->
             MatchResponse.from(match, getPlayersByTeamId(match))
         }
+
+    fun getAllPaged(
+        page: Int,
+        size: Int,
+        filter: MatchFilterRequest,
+        sortParam: SortParam = DEFAULT_SORT,
+    ): PageResponse<MatchResponse> {
+        val filteredMatches = matchService.findAllFiltered(filter)
+        val totalElements = filteredMatches.size.toLong()
+
+        val sortedMatches = filteredMatches.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
+
+        val content = sortedMatches
+            .drop(page * size)
+            .take(size)
+            .map { match ->
+                MatchResponse.from(match, getPlayersByTeamId(match))
+            }
+
+        return PageResponse.of(content, totalElements, page, size)
+    }
 
     fun getById(id: UUID): MatchResponse? {
         val match = matchService.get(id) ?: return null

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
@@ -1,10 +1,14 @@
 package com.github.mihanizzm.ultistats.facade
 
+import com.github.mihanizzm.ultistats.dto.common.PageResponse
+import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.dto.response.PlayerResponse
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -13,8 +17,38 @@ class PlayerFacade(
     private val playerService: PlayerService,
     private val teamService: TeamService,
 ) {
+    companion object {
+        val DEFAULT_SORT = SortParam("lastName")
+
+        val SORT_FIELD_EXTRACTORS: Map<String, (Player) -> Comparable<*>?> = mapOf(
+            "lastName" to { it.lastName },
+            "firstName" to { it.firstName },
+            "number" to { it.number },
+            "teamId" to { it.teamId?.toString() },
+        )
+    }
+
     fun getAll(): List<PlayerResponse> =
         playerService.getAll().map { PlayerResponse.from(it) }
+
+    fun getAllPaged(
+        page: Int,
+        size: Int,
+        filter: PlayerFilterRequest,
+        sortParam: SortParam = DEFAULT_SORT,
+    ): PageResponse<PlayerResponse> {
+        val filteredPlayers = playerService.findAllFiltered(filter)
+        val totalElements = filteredPlayers.size.toLong()
+
+        val sortedPlayers = filteredPlayers.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
+
+        val content = sortedPlayers
+            .drop(page * size)
+            .take(size)
+            .map { PlayerResponse.from(it) }
+
+        return PageResponse.of(content, totalElements, page, size)
+    }
 
     fun getById(id: UUID): PlayerResponse? {
         val player = playerService.get(id) ?: return null

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
@@ -1,10 +1,14 @@
 package com.github.mihanizzm.ultistats.facade
 
+import com.github.mihanizzm.ultistats.dto.common.PageResponse
+import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.dto.response.TeamResponse
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -13,11 +17,41 @@ class TeamFacade(
     private val teamService: TeamService,
     private val playerService: PlayerService,
 ) {
+    companion object {
+        val DEFAULT_SORT = SortParam("name")
+
+        val SORT_FIELD_EXTRACTORS: Map<String, (Team) -> Comparable<*>?> = mapOf(
+            "name" to { it.name },
+        )
+    }
+
     fun getAll(): List<TeamResponse> =
         teamService.getAll().map { team ->
             val players = playerService.getAllByIds(team.playerIds)
             TeamResponse.from(team, players)
         }
+
+    fun getAllPaged(
+        page: Int,
+        size: Int,
+        filter: TeamFilterRequest,
+        sortParam: SortParam = DEFAULT_SORT,
+    ): PageResponse<TeamResponse> {
+        val filteredTeams = teamService.findAllFiltered(filter)
+        val totalElements = filteredTeams.size.toLong()
+
+        val sortedTeams = filteredTeams.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
+
+        val content = sortedTeams
+            .drop(page * size)
+            .take(size)
+            .map { team ->
+                val players = playerService.getAllByIds(team.playerIds)
+                TeamResponse.from(team, players)
+            }
+
+        return PageResponse.of(content, totalElements, page, size)
+    }
 
     fun getById(id: UUID): TeamResponse? {
         val team = teamService.get(id) ?: return null

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
@@ -12,4 +12,11 @@ data class Match(
     val plannedStartTimestamp: Instant? = null,
     var startedAt: Instant? = null,
     var endedAt: Instant? = null,
-)
+) {
+    val status: MatchStatus
+        get() = when {
+            endedAt != null -> MatchStatus.FINISHED
+            startedAt != null -> MatchStatus.IN_PROGRESS
+            else -> MatchStatus.PLANNED
+        }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchStatus.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchStatus.kt
@@ -1,0 +1,7 @@
+package com.github.mihanizzm.ultistats.model
+
+enum class MatchStatus {
+    PLANNED,
+    IN_PROGRESS,
+    FINISHED,
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchRepository.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.model.Match
 import java.util.UUID
 
@@ -11,4 +12,10 @@ interface MatchRepository {
     fun delete(id: UUID)
 
     fun getAll(): List<Match>
+
+    fun findAllFiltered(filter: MatchFilterRequest): List<Match>
+
+    fun count(): Long
+
+    fun countFiltered(filter: MatchFilterRequest): Long
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchRepositoryConcurrentMapImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchRepositoryConcurrentMapImpl.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.model.Match
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -21,4 +22,38 @@ class MatchRepositoryConcurrentMapImpl : MatchRepository {
     }
 
     override fun getAll(): List<Match> = matches.values.toList()
+
+    override fun findAllFiltered(filter: MatchFilterRequest): List<Match> =
+        matches.values.filter { match -> matchesFilter(match, filter) }.toList()
+
+    override fun count(): Long = matches.size.toLong()
+
+    override fun countFiltered(filter: MatchFilterRequest): Long =
+        matches.values.count { match -> matchesFilter(match, filter) }.toLong()
+
+    private fun matchesFilter(match: Match, filter: MatchFilterRequest): Boolean {
+        if (filter.teamId != null) {
+            val teamIds = match.teams.map { it.id }
+            if (filter.teamId !in teamIds) {
+                return false
+            }
+        }
+        if (filter.status != null && match.status != filter.status) {
+            return false
+        }
+        if (filter.dateFrom != null || filter.dateTo != null) {
+            val matchDate = match.startedAt ?: match.plannedStartTimestamp
+            if (matchDate != null) {
+                if (filter.dateFrom != null && matchDate < filter.dateFrom) {
+                    return false
+                }
+                if (filter.dateTo != null && matchDate > filter.dateTo) {
+                    return false
+                }
+            } else if (filter.dateFrom != null || filter.dateTo != null) {
+                return false
+            }
+        }
+        return true
+    }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchService.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.model.Match
 import java.time.Instant
 import java.util.UUID
@@ -14,6 +15,12 @@ interface MatchService {
     fun delete(matchId: UUID)
 
     fun getAll(): List<Match>
+
+    fun findAllFiltered(filter: MatchFilterRequest): List<Match>
+
+    fun count(): Long
+
+    fun countFiltered(filter: MatchFilterRequest): Long
 
     /**
      * Пересчитать владельца диска на основе списка событий матча.

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.exception.EntityNotFoundException
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.events.*
@@ -25,6 +26,14 @@ class MatchServiceImpl(
     override fun delete(matchId: UUID) = matchRepository.delete(matchId)
 
     override fun getAll(): List<Match> = matchRepository.getAll()
+
+    override fun findAllFiltered(filter: MatchFilterRequest): List<Match> =
+        matchRepository.findAllFiltered(filter)
+
+    override fun count(): Long = matchRepository.count()
+
+    override fun countFiltered(filter: MatchFilterRequest): Long =
+        matchRepository.countFiltered(filter)
 
     override fun recalculateDiskHolder(matchId: UUID) {
         val match = getOrThrow(matchId)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerRepository.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.model.Player
 import java.util.UUID
 
@@ -15,4 +16,10 @@ interface PlayerRepository {
     fun getAllByIds(ids: List<UUID>): List<Player>
 
     fun getAllByTeamId(teamId: UUID): List<Player>
+
+    fun findAllFiltered(filter: PlayerFilterRequest): List<Player>
+
+    fun count(): Long
+
+    fun countFiltered(filter: PlayerFilterRequest): Long
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerRepositoryConcurrentMapImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerRepositoryConcurrentMapImpl.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.model.Player
 import org.springframework.stereotype.Repository
 import java.util.UUID
@@ -25,4 +26,26 @@ class PlayerRepositoryConcurrentMapImpl : PlayerRepository {
 
     override fun getAllByTeamId(teamId: UUID): List<Player> =
         players.values.filter { it.teamId == teamId }.toList()
+
+    override fun findAllFiltered(filter: PlayerFilterRequest): List<Player> =
+        players.values.filter { player -> matchesFilter(player, filter) }.toList()
+
+    override fun count(): Long = players.size.toLong()
+
+    override fun countFiltered(filter: PlayerFilterRequest): Long =
+        players.values.count { player -> matchesFilter(player, filter) }.toLong()
+
+    private fun matchesFilter(player: Player, filter: PlayerFilterRequest): Boolean {
+        if (filter.teamId != null && player.teamId != filter.teamId) {
+            return false
+        }
+        if (filter.name != null) {
+            val searchName = filter.name.lowercase()
+            val fullName = "${player.firstName} ${player.lastName}".lowercase()
+            if (!fullName.contains(searchName)) {
+                return false
+            }
+        }
+        return true
+    }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerService.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.model.Player
 import java.util.UUID
 
@@ -17,4 +18,10 @@ interface PlayerService {
     fun getAllByIds(ids: List<UUID>): List<Player>
 
     fun getAllByTeamId(teamId: UUID): List<Player>
+
+    fun findAllFiltered(filter: PlayerFilterRequest): List<Player>
+
+    fun count(): Long
+
+    fun countFiltered(filter: PlayerFilterRequest): Long
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.model.Player
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -24,4 +25,12 @@ class PlayerServiceImpl(
     override fun getAllByIds(ids: List<UUID>): List<Player> = playerRepository.getAllByIds(ids)
 
     override fun getAllByTeamId(teamId: UUID): List<Player> = playerRepository.getAllByTeamId(teamId)
+
+    override fun findAllFiltered(filter: PlayerFilterRequest): List<Player> =
+        playerRepository.findAllFiltered(filter)
+
+    override fun count(): Long = playerRepository.count()
+
+    override fun countFiltered(filter: PlayerFilterRequest): Long =
+        playerRepository.countFiltered(filter)
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamRepository.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.model.Team
 import java.util.*
 
@@ -13,4 +14,10 @@ interface TeamRepository {
     fun getAll(): List<Team>
 
     fun getAllInList(ids: List<UUID>): List<Team>
+
+    fun findAllFiltered(filter: TeamFilterRequest): List<Team>
+
+    fun count(): Long
+
+    fun countFiltered(filter: TeamFilterRequest): Long
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamRepositoryConcurrentMapImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamRepositoryConcurrentMapImpl.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.model.Team
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -23,4 +24,22 @@ class TeamRepositoryConcurrentMapImpl : TeamRepository {
     override fun getAll(): List<Team> = teams.values.toList()
 
     override fun getAllInList(ids: List<UUID>): List<Team> = ids.mapNotNull { get(it) }
+
+    override fun findAllFiltered(filter: TeamFilterRequest): List<Team> =
+        teams.values.filter { team -> matchesFilter(team, filter) }.toList()
+
+    override fun count(): Long = teams.size.toLong()
+
+    override fun countFiltered(filter: TeamFilterRequest): Long =
+        teams.values.count { team -> matchesFilter(team, filter) }.toLong()
+
+    private fun matchesFilter(team: Team, filter: TeamFilterRequest): Boolean {
+        if (filter.name != null) {
+            val searchName = filter.name.lowercase()
+            if (!team.name.lowercase().contains(searchName)) {
+                return false
+            }
+        }
+        return true
+    }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamService.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.model.Team
 import java.util.UUID
 
@@ -13,4 +14,10 @@ interface TeamService {
     fun getAll(): List<Team>
 
     fun getAllInList(ids: List<UUID>): List<Team>
+
+    fun findAllFiltered(filter: TeamFilterRequest): List<Team>
+
+    fun count(): Long
+
+    fun countFiltered(filter: TeamFilterRequest): Long
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.service
 
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.model.Team
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -21,4 +22,12 @@ class TeamServiceImpl(
     override fun getAll(): List<Team> = teamRepository.getAll()
 
     override fun getAllInList(ids: List<UUID>): List<Team> = teamRepository.getAllInList(ids)
+
+    override fun findAllFiltered(filter: TeamFilterRequest): List<Team> =
+        teamRepository.findAllFiltered(filter)
+
+    override fun count(): Long = teamRepository.count()
+
+    override fun countFiltered(filter: TeamFilterRequest): Long =
+        teamRepository.countFiltered(filter)
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/util/SortingUtils.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/util/SortingUtils.kt
@@ -1,0 +1,46 @@
+package com.github.mihanizzm.ultistats.util
+
+import com.github.mihanizzm.ultistats.dto.common.SortDirection
+import com.github.mihanizzm.ultistats.dto.common.SortParam
+
+object SortingUtils {
+    /**
+     * Создаёт компаратор на основе параметра сортировки.
+     *
+     * @param sortParam параметр сортировки (например, ("lastName", DESC))
+     * @param fieldExtractors маппинг имени поля на функцию извлечения значения
+     * @return Comparator для сортировки или null, если поле не найдено
+     */
+    fun <T> buildComparator(
+        sortParam: SortParam,
+        fieldExtractors: Map<String, (T) -> Comparable<*>?>,
+    ): Comparator<T>? {
+        val extractor = fieldExtractors[sortParam.field] ?: return null
+
+        @Suppress("UNCHECKED_CAST")
+        val fieldComparator = compareBy<T, Comparable<Any>?>(
+            nullsLast()
+        ) { extractor(it) as? Comparable<Any> }
+
+        return if (sortParam.direction == SortDirection.DESC) {
+            fieldComparator.reversed()
+        } else {
+            fieldComparator
+        }
+    }
+
+    /**
+     * Применяет сортировку к списку.
+     */
+    fun <T> List<T>.applySorting(
+        sortParam: SortParam,
+        fieldExtractors: Map<String, (T) -> Comparable<*>?>,
+    ): List<T> {
+        val comparator = buildComparator(sortParam, fieldExtractors)
+        return if (comparator != null) {
+            this.sortedWith(comparator)
+        } else {
+            this
+        }
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
@@ -2,6 +2,8 @@ package com.github.mihanizzm.ultistats.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
+import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
+import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.MatchService
@@ -16,6 +18,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.time.Instant
 import java.util.UUID
 
 @SpringBootTest
@@ -119,6 +122,171 @@ class MatchControllerTest {
 
         mockMvc.perform(get("/api/v1/matches/$matchId"))
             .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Получение матчей с пагинацией возвращает PageResponse`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+        createTestMatch(team1, team2)
+        createTestMatch(team1, team2)
+
+        mockMvc.perform(get("/api/v1/matches"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+            .andExpect(jsonPath("$.currentPage").value(0))
+    }
+
+    @Test
+    fun `Фильтрация матчей по команде работает`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+        val team3 = createTestTeam("Команда 3")
+
+        createTestMatch(team1, team2)
+        createTestMatch(team1, team3)
+        createTestMatch(team2, team3)
+
+        mockMvc.perform(get("/api/v1/matches").param("teamId", team1.id.toString()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+    }
+
+    @Test
+    fun `Фильтрация матчей по статусу работает`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+
+        val plannedMatch = createTestMatch(team1, team2)
+        val inProgressMatch = createTestMatch(team1, team2)
+        matchService.startMatch(inProgressMatch.id, Instant.now())
+
+        mockMvc.perform(get("/api/v1/matches").param("status", "PLANNED"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.totalElements").value(1))
+
+        mockMvc.perform(get("/api/v1/matches").param("status", "IN_PROGRESS"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.totalElements").value(1))
+    }
+
+    @Test
+    fun `Пагинация матчей работает`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+
+        for (i in 1..5) {
+            createTestMatch(team1, team2)
+        }
+
+        mockMvc.perform(
+            get("/api/v1/matches")
+                .param("page", "0")
+                .param("size", "2")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(5))
+            .andExpect(jsonPath("$.totalPages").value(3))
+            .andExpect(jsonPath("$.currentPage").value(0))
+
+        mockMvc.perform(
+            get("/api/v1/matches")
+                .param("page", "2")
+                .param("size", "2")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.currentPage").value(2))
+    }
+
+    @Test
+    fun `Сортировка по умолчанию работает (plannedStartTimestamp)`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+
+        val now = Instant.now()
+        createTestMatchWithTimestamp(team1, team2, now.plusSeconds(3600)) // через час
+        createTestMatchWithTimestamp(team1, team2, now.plusSeconds(1800)) // через 30 мин
+        createTestMatchWithTimestamp(team1, team2, now.plusSeconds(7200)) // через 2 часа
+
+        mockMvc.perform(get("/api/v1/matches"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(3))
+            // По умолчанию ASC - сначала ближайший
+            .andExpect(jsonPath("$.content[0].plannedStartTimestamp").exists())
+    }
+
+    @Test
+    fun `Сортировка по plannedStartTimestamp по убыванию работает`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+
+        val now = Instant.now()
+        val match1 = createTestMatchWithTimestamp(team1, team2, now.plusSeconds(1000))
+        val match2 = createTestMatchWithTimestamp(team1, team2, now.plusSeconds(2000))
+        val match3 = createTestMatchWithTimestamp(team1, team2, now.plusSeconds(3000))
+
+        mockMvc.perform(
+            get("/api/v1/matches")
+                .param("sort", "plannedStartTimestamp:desc")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(match3.id.toString()))
+            .andExpect(jsonPath("$.content[1].id").value(match2.id.toString()))
+            .andExpect(jsonPath("$.content[2].id").value(match1.id.toString()))
+    }
+
+    @Test
+    fun `Сортировка по статусу работает`() {
+        val team1 = createTestTeam("Команда 1")
+        val team2 = createTestTeam("Команда 2")
+
+        // PLANNED
+        createTestMatch(team1, team2)
+
+        // IN_PROGRESS
+        val inProgressMatch = createTestMatch(team1, team2)
+        matchService.startMatch(inProgressMatch.id, Instant.now())
+
+        // FINISHED
+        val finishedMatch = createTestMatch(team1, team2)
+        matchService.startMatch(finishedMatch.id, Instant.now())
+        matchService.endMatch(finishedMatch.id, Instant.now())
+
+        mockMvc.perform(
+            get("/api/v1/matches")
+                .param("sort", "status:asc")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(3))
+            // FINISHED < IN_PROGRESS < PLANNED (alphabetically)
+            .andExpect(jsonPath("$.content[0].status").value("FINISHED"))
+            .andExpect(jsonPath("$.content[1].status").value("IN_PROGRESS"))
+            .andExpect(jsonPath("$.content[2].status").value("PLANNED"))
+    }
+
+    private fun createTestMatchWithTimestamp(team1: Team, team2: Team, plannedStart: Instant): Match {
+        val match = Match(
+            id = UUID.randomUUID(),
+            teams = listOf(team1, team2),
+            plannedStartTimestamp = plannedStart,
+        )
+        matchService.create(match)
+        return match
+    }
+
+    private fun createTestMatch(team1: Team, team2: Team): Match {
+        val match = Match(
+            id = UUID.randomUUID(),
+            teams = listOf(team1, team2),
+        )
+        matchService.create(match)
+        return match
     }
 
     private fun createTestTeam(name: String): Team {

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/PlayerControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/PlayerControllerTest.kt
@@ -1,0 +1,248 @@
+package com.github.mihanizzm.ultistats.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.service.PlayerService
+import com.github.mihanizzm.ultistats.service.TeamService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Suppress("NonAsciiCharacters")
+class PlayerControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var playerService: PlayerService
+
+    @Autowired
+    lateinit var teamService: TeamService
+
+    @BeforeEach
+    fun setup() {
+        teamService.getAll().forEach { teamService.delete(it.id) }
+        playerService.getAll().forEach { playerService.delete(it.id) }
+    }
+
+    @Test
+    fun `Получение игроков с пагинацией возвращает PageResponse`() {
+        createTestPlayer("Иван", "Иванов")
+        createTestPlayer("Пётр", "Петров")
+
+        mockMvc.perform(get("/api/v1/players"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+            .andExpect(jsonPath("$.currentPage").value(0))
+    }
+
+    @Test
+    fun `Фильтрация игроков по имени работает`() {
+        createTestPlayer("Иван", "Иванов")
+        createTestPlayer("Пётр", "Иванов")
+        createTestPlayer("Сергей", "Сергеев")
+
+        mockMvc.perform(get("/api/v1/players").param("name", "Иванов"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+    }
+
+    @Test
+    fun `Фильтрация игроков по команде работает`() {
+        val team = createTestTeam()
+        createTestPlayer("Иван", "Иванов", team.id)
+        createTestPlayer("Пётр", "Петров", team.id)
+        createTestPlayer("Сергей", "Сергеев", null)
+
+        mockMvc.perform(get("/api/v1/players").param("teamId", team.id.toString()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+    }
+
+    @Test
+    fun `Пагинация игроков работает`() {
+        for (i in 1..5) {
+            createTestPlayer("Игрок$i", "Фамилия$i")
+        }
+
+        mockMvc.perform(
+            get("/api/v1/players")
+                .param("page", "0")
+                .param("size", "2")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(5))
+            .andExpect(jsonPath("$.totalPages").value(3))
+            .andExpect(jsonPath("$.currentPage").value(0))
+
+        mockMvc.perform(
+            get("/api/v1/players")
+                .param("page", "2")
+                .param("size", "2")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.currentPage").value(2))
+    }
+
+    @Test
+    fun `Комбинированная фильтрация работает`() {
+        val team = createTestTeam()
+        createTestPlayer("Алексей", "Смирнов", team.id)
+        createTestPlayer("Алексей", "Козлов", null)
+        createTestPlayer("Пётр", "Петров", team.id)
+
+        mockMvc.perform(
+            get("/api/v1/players")
+                .param("name", "Алексей")
+                .param("teamId", team.id.toString())
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].firstName").value("Алексей"))
+            .andExpect(jsonPath("$.content[0].lastName").value("Смирнов"))
+    }
+
+    @Test
+    fun `Создание игрока возвращает 201`() {
+        val request = CreatePlayerRequest(
+            number = 10,
+            firstName = "Иван",
+            lastName = "Иванов",
+        )
+
+        mockMvc.perform(
+            post("/api/v1/players")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.firstName").value("Иван"))
+            .andExpect(jsonPath("$.lastName").value("Иванов"))
+            .andExpect(jsonPath("$.id").exists())
+    }
+
+    @Test
+    fun `Получение игрока по ID возвращает 200`() {
+        val player = createTestPlayer("Иван", "Иванов")
+
+        mockMvc.perform(get("/api/v1/players/${player.id}"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.firstName").value("Иван"))
+    }
+
+    @Test
+    fun `Получение несуществующего игрока возвращает 404`() {
+        mockMvc.perform(get("/api/v1/players/${UUID.randomUUID()}"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Удаление игрока возвращает 204`() {
+        val player = createTestPlayer("Иван", "Иванов")
+
+        mockMvc.perform(delete("/api/v1/players/${player.id}"))
+            .andExpect(status().isNoContent)
+
+        mockMvc.perform(get("/api/v1/players/${player.id}"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Сортировка по умолчанию работает (lastName, firstName)`() {
+        createTestPlayerWithNumber("Борис", "Яковлев", 1)
+        createTestPlayerWithNumber("Анна", "Иванова", 2)
+        createTestPlayerWithNumber("Виктор", "Иванов", 3)
+
+        mockMvc.perform(get("/api/v1/players"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].lastName").value("Иванов"))
+            .andExpect(jsonPath("$.content[0].firstName").value("Виктор"))
+            .andExpect(jsonPath("$.content[1].lastName").value("Иванова"))
+            .andExpect(jsonPath("$.content[2].lastName").value("Яковлев"))
+    }
+
+    @Test
+    fun `Сортировка по номеру работает`() {
+        createTestPlayerWithNumber("Игрок", "Первый", 10)
+        createTestPlayerWithNumber("Игрок", "Второй", 5)
+        createTestPlayerWithNumber("Игрок", "Третий", 15)
+
+        mockMvc.perform(
+            get("/api/v1/players")
+                .param("sort", "number:asc")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].number").value(5))
+            .andExpect(jsonPath("$.content[1].number").value(10))
+            .andExpect(jsonPath("$.content[2].number").value(15))
+    }
+
+    @Test
+    fun `Сортировка по убыванию работает`() {
+        createTestPlayerWithNumber("Игрок", "Альфа", 1)
+        createTestPlayerWithNumber("Игрок", "Бета", 2)
+        createTestPlayerWithNumber("Игрок", "Гамма", 3)
+
+        mockMvc.perform(
+            get("/api/v1/players")
+                .param("sort", "lastName:desc")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].lastName").value("Гамма"))
+            .andExpect(jsonPath("$.content[1].lastName").value("Бета"))
+            .andExpect(jsonPath("$.content[2].lastName").value("Альфа"))
+    }
+
+    private fun createTestPlayerWithNumber(firstName: String, lastName: String, number: Int): Player {
+        val player = Player(
+            id = UUID.randomUUID(),
+            teamId = null,
+            number = number,
+            firstName = firstName,
+            lastName = lastName,
+        )
+        playerService.create(player)
+        return player
+    }
+
+    private fun createTestPlayer(firstName: String, lastName: String, teamId: UUID? = null): Player {
+        val player = Player(
+            id = UUID.randomUUID(),
+            teamId = teamId,
+            number = (1..99).random(),
+            firstName = firstName,
+            lastName = lastName,
+        )
+        playerService.create(player)
+        return player
+    }
+
+    private fun createTestTeam(): Team {
+        val team = Team(
+            id = UUID.randomUUID(),
+            name = "Test Team",
+            playerIds = emptyList(),
+        )
+        teamService.create(team)
+        return team
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
@@ -82,13 +82,54 @@ class TeamControllerTest {
     }
 
     @Test
-    fun `Получение всех команд возвращает список`() {
+    fun `Получение всех команд с пагинацией возвращает PageResponse`() {
         createTestTeam("Team 1")
         createTestTeam("Team 2")
 
         mockMvc.perform(get("/api/v1/teams"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+            .andExpect(jsonPath("$.currentPage").value(0))
+    }
+
+    @Test
+    fun `Фильтрация команд по имени работает`() {
+        createTestTeam("Alpha Team")
+        createTestTeam("Beta Team")
+        createTestTeam("Gamma")
+
+        mockMvc.perform(get("/api/v1/teams").param("name", "Team"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(2))
+    }
+
+    @Test
+    fun `Пагинация команд работает`() {
+        for (i in 1..5) {
+            createTestTeam("Team $i")
+        }
+
+        mockMvc.perform(
+            get("/api/v1/teams")
+                .param("page", "0")
+                .param("size", "2")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.totalElements").value(5))
+            .andExpect(jsonPath("$.totalPages").value(3))
+            .andExpect(jsonPath("$.currentPage").value(0))
+
+        mockMvc.perform(
+            get("/api/v1/teams")
+                .param("page", "2")
+                .param("size", "2")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.currentPage").value(2))
     }
 
     @Test
@@ -128,6 +169,35 @@ class TeamControllerTest {
         mockMvc.perform(delete("/api/v1/teams/${team.id}/players/$playerId"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.players.length()").value(players.size - 1))
+    }
+
+    @Test
+    fun `Сортировка команд по имени работает`() {
+        createTestTeam("Gamma Team")
+        createTestTeam("Alpha Team")
+        createTestTeam("Beta Team")
+
+        mockMvc.perform(get("/api/v1/teams"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].name").value("Alpha Team"))
+            .andExpect(jsonPath("$.content[1].name").value("Beta Team"))
+            .andExpect(jsonPath("$.content[2].name").value("Gamma Team"))
+    }
+
+    @Test
+    fun `Сортировка команд по убыванию работает`() {
+        createTestTeam("Alpha")
+        createTestTeam("Beta")
+        createTestTeam("Gamma")
+
+        mockMvc.perform(
+            get("/api/v1/teams")
+                .param("sort", "name:desc")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].name").value("Gamma"))
+            .andExpect(jsonPath("$.content[1].name").value("Beta"))
+            .andExpect(jsonPath("$.content[2].name").value("Alpha"))
     }
 
     private fun createTestTeam(name: String = "Test Team"): Pair<Team, List<Player>> {

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/util/SortingIntegrationTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/util/SortingIntegrationTest.kt
@@ -1,0 +1,39 @@
+package com.github.mihanizzm.ultistats.util
+
+import com.github.mihanizzm.ultistats.dto.common.SortDirection
+import com.github.mihanizzm.ultistats.dto.common.SortParam
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
+import com.github.mihanizzm.ultistats.facade.PlayerFacade
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import java.util.UUID
+
+@Suppress("NonAsciiCharacters")
+class SortingIntegrationTest {
+
+    @Test
+    fun `Сортировка игроков по убыванию фамилии работает`() {
+        val players = listOf(
+            Player(UUID.randomUUID(), null, 1, "Игрок", "Альфа"),
+            Player(UUID.randomUUID(), null, 2, "Игрок", "Бета"),
+            Player(UUID.randomUUID(), null, 3, "Игрок", "Гамма"),
+        )
+
+        val sortParam = SortParam("lastName", SortDirection.DESC)
+        val sorted = players.applySorting(sortParam, PlayerFacade.SORT_FIELD_EXTRACTORS)
+
+        // Гамма > Бета > Альфа в Unicode, так что DESC должен дать Гамма первым
+        assertEquals("Гамма", sorted[0].lastName)
+        assertEquals("Бета", sorted[1].lastName)
+        assertEquals("Альфа", sorted[2].lastName)
+    }
+
+    @Test
+    fun `SortParam парсит desc из строки`() {
+        val param = SortParam.parse("lastName:desc")
+
+        assertEquals("lastName", param.field)
+        assertEquals(SortDirection.DESC, param.direction)
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/util/SortingUtilsTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/util/SortingUtilsTest.kt
@@ -1,0 +1,72 @@
+package com.github.mihanizzm.ultistats.util
+
+import com.github.mihanizzm.ultistats.dto.common.SortDirection
+import com.github.mihanizzm.ultistats.dto.common.SortParam
+import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+
+@Suppress("NonAsciiCharacters")
+class SortingUtilsTest {
+
+    data class TestItem(val name: String, val value: Int)
+
+    private val extractors: Map<String, (TestItem) -> Comparable<*>?> = mapOf(
+        "name" to { it.name },
+        "value" to { it.value },
+    )
+
+    @Test
+    fun `Сортировка по возрастанию работает`() {
+        val items = listOf(
+            TestItem("C", 3),
+            TestItem("A", 1),
+            TestItem("B", 2),
+        )
+
+        val sorted = items.applySorting(SortParam("name", SortDirection.ASC), extractors)
+
+        assertEquals("A", sorted[0].name)
+        assertEquals("B", sorted[1].name)
+        assertEquals("C", sorted[2].name)
+    }
+
+    @Test
+    fun `Сортировка по убыванию работает`() {
+        val items = listOf(
+            TestItem("A", 1),
+            TestItem("B", 2),
+            TestItem("C", 3),
+        )
+
+        val sorted = items.applySorting(SortParam("name", SortDirection.DESC), extractors)
+
+        assertEquals("C", sorted[0].name)
+        assertEquals("B", sorted[1].name)
+        assertEquals("A", sorted[2].name)
+    }
+
+    @Test
+    fun `Парсинг DESC работает`() {
+        val param = SortParam.parse("name:desc")
+
+        assertEquals("name", param.field)
+        assertEquals(SortDirection.DESC, param.direction)
+    }
+
+    @Test
+    fun `Парсинг ASC работает`() {
+        val param = SortParam.parse("name:asc")
+
+        assertEquals("name", param.field)
+        assertEquals(SortDirection.ASC, param.direction)
+    }
+
+    @Test
+    fun `Парсинг без направления возвращает ASC`() {
+        val param = SortParam.parse("name")
+
+        assertEquals("name", param.field)
+        assertEquals(SortDirection.ASC, param.direction)
+    }
+}


### PR DESCRIPTION
## Summary
- Добавлена пагинация для всех основных сущностей (игроки, команды, матчи)
- Добавлена фильтрация:
  - Игроки: по имени, по команде
  - Команды: по названию
  - Матчи: по команде, по статусу, по диапазону дат
- Добавлена сортировка с дефолтными значениями (формат: `field:direction`)

## API Examples

```
GET /api/v1/players?page=0&size=20&name=Иван&sort=lastName:desc
GET /api/v1/teams?page=0&size=10&name=Team&sort=name:asc
GET /api/v1/matches?status=PLANNED&dateFrom=2024-01-01T00:00:00Z&sort=plannedStartTimestamp:asc
```

## Test plan
- [x] Все 91 тест проходят
- [ ] Проверить работу пагинации через Swagger UI
- [ ] Проверить работу фильтрации
- [ ] Проверить работу сортировки

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)