### PR TITLE
#32: Добавить Spring Converter для SortParam

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/config/SortParamConverter.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/config/SortParamConverter.kt
@@ -1,0 +1,10 @@
+package com.github.mihanizzm.ultistats.config
+
+import com.github.mihanizzm.ultistats.dto.common.SortParam
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+
+@Component
+class SortParamConverter : Converter<String, SortParam> {
+    override fun convert(source: String): SortParam = SortParam.parse(source)
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -57,7 +57,7 @@ class MatchController(
             example = "plannedStartTimestamp:asc"
         )
         @RequestParam(required = false)
-        sort: String?,
+        sort: SortParam?,
     ): PageResponse<MatchResponse> {
         val filter = MatchFilterRequest(
             teamId = teamId,
@@ -65,8 +65,7 @@ class MatchController(
             dateFrom = dateFrom,
             dateTo = dateTo,
         )
-        val sortParam = sort?.let { SortParam.parse(it) } ?: MatchFacade.DEFAULT_SORT
-        return matchFacade.getAllPaged(page, size, filter, sortParam)
+        return matchFacade.getAllPaged(page, size, filter, sort ?: MatchFacade.DEFAULT_SORT)
     }
 
     @GetMapping("/{id}")

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
@@ -46,11 +46,10 @@ class PlayerController(
             example = "lastName:asc"
         )
         @RequestParam(required = false)
-        sort: String?,
+        sort: SortParam?,
     ): PageResponse<PlayerResponse> {
         val filter = PlayerFilterRequest(name = name, teamId = teamId)
-        val sortParam = sort?.let { SortParam.parse(it) } ?: PlayerFacade.DEFAULT_SORT
-        return playerFacade.getAllPaged(page, size, filter, sortParam)
+        return playerFacade.getAllPaged(page, size, filter, sort ?: PlayerFacade.DEFAULT_SORT)
     }
 
     @GetMapping("/{id}")

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -41,11 +41,10 @@ class TeamController(
             example = "name:asc"
         )
         @RequestParam(required = false)
-        sort: String?,
+        sort: SortParam?,
     ): PageResponse<TeamResponse> {
         val filter = TeamFilterRequest(name = name)
-        val sortParam = sort?.let { SortParam.parse(it) } ?: TeamFacade.DEFAULT_SORT
-        return teamFacade.getAllPaged(page, size, filter, sortParam)
+        return teamFacade.getAllPaged(page, size, filter, sort ?: TeamFacade.DEFAULT_SORT)
     }
 
     @GetMapping("/{id}")


### PR DESCRIPTION
## Summary
- Создан `SortParamConverter` для автоматического преобразования строкового query parameter в `SortParam`
- Контроллеры теперь принимают `SortParam?` напрямую вместо ручного парсинга через `SortParam.parse()`

## Test plan
- [x] Компиляция проходит
- [x] Все тесты проходят
- [ ] Проверить API через Swagger: `?sort=name:asc`, `?sort=name:desc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)