### PR TITLE
#19: Добавить автосохранение данных в JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ out/
 
 ### Claude Code ###
 CLAUDE.md
+
+### Persistence Data ###
+data/

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/UltistatsApplication.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/UltistatsApplication.kt
@@ -2,8 +2,10 @@ package com.github.mihanizzm.ultistats
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class UltistatsApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/config/JacksonConfig.kt
@@ -1,0 +1,20 @@
+package com.github.mihanizzm.ultistats.config
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JacksonConfig {
+    @Bean
+    fun objectMapper(): ObjectMapper = ObjectMapper()
+        .registerModule(JavaTimeModule())
+        .registerModule(KotlinModule.Builder().build())
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        .enable(SerializationFeature.INDENT_OUTPUT)
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
@@ -1,5 +1,6 @@
 package com.github.mihanizzm.ultistats.model
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.github.mihanizzm.ultistats.model.events.Event
 import java.time.Instant
 import java.util.UUID
@@ -13,6 +14,7 @@ data class Match(
     var startedAt: Instant? = null,
     var endedAt: Instant? = null,
 ) {
+    @get:JsonIgnore
     val status: MatchStatus
         get() = when {
             endedAt != null -> MatchStatus.FINISHED

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/Event.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/Event.kt
@@ -1,7 +1,16 @@
 package com.github.mihanizzm.ultistats.model.events
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Instant
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_eventClass")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = OnePlayerEvent::class, name = "OnePlayerEvent"),
+    JsonSubTypes.Type(value = TwoPlayerEvent::class, name = "TwoPlayerEvent"),
+    JsonSubTypes.Type(value = TeamEvent::class, name = "TeamEvent"),
+    JsonSubTypes.Type(value = SystemEvent::class, name = "SystemEvent"),
+)
 sealed interface Event {
     val realTimestamp: Instant
     val type: EventType

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/persistence/JsonPersistenceService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/persistence/JsonPersistenceService.kt
@@ -1,0 +1,78 @@
+package com.github.mihanizzm.ultistats.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.service.MatchRepository
+import com.github.mihanizzm.ultistats.service.PlayerRepository
+import com.github.mihanizzm.ultistats.service.TeamRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.io.File
+
+@Service
+class JsonPersistenceService(
+    private val matchRepository: MatchRepository,
+    private val teamRepository: TeamRepository,
+    private val playerRepository: PlayerRepository,
+    private val objectMapper: ObjectMapper,
+    @Value("\${ultistats.persistence.path:./data/ultistats.json}")
+    private val persistencePath: String,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(fixedRateString = "\${ultistats.persistence.interval:30000}")
+    fun scheduledSave() {
+        try {
+            save()
+        } catch (e: Exception) {
+            logger.error("Failed to save data", e)
+        }
+    }
+
+    fun save() {
+        val data = PersistenceData(
+            matches = matchRepository.getAll(),
+            teams = teamRepository.getAll(),
+            players = playerRepository.getAll(),
+        )
+        val file = File(persistencePath)
+        file.parentFile?.mkdirs()
+
+        val tempFile = File("${persistencePath}.tmp")
+        objectMapper.writeValue(tempFile, data)
+        if (!tempFile.renameTo(file)) {
+            file.delete()
+            tempFile.renameTo(file)
+        }
+
+        logger.debug("Data saved to {}", persistencePath)
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun load() {
+        val file = File(persistencePath)
+        if (!file.exists()) {
+            logger.info("No persistence file found at {}, starting with empty data", persistencePath)
+            return
+        }
+
+        try {
+            val data = objectMapper.readValue(file, PersistenceData::class.java)
+            data.players.forEach { playerRepository.save(it) }
+            data.teams.forEach { teamRepository.save(it) }
+            data.matches.forEach { matchRepository.save(it) }
+            logger.info(
+                "Loaded {} matches, {} teams, {} players from {}",
+                data.matches.size,
+                data.teams.size,
+                data.players.size,
+                persistencePath
+            )
+        } catch (e: Exception) {
+            logger.error("Failed to load data from {}", persistencePath, e)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/persistence/PersistenceData.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/persistence/PersistenceData.kt
@@ -1,0 +1,14 @@
+package com.github.mihanizzm.ultistats.persistence
+
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import java.time.Instant
+
+data class PersistenceData(
+    val version: Int = 1,
+    val savedAt: Instant = Instant.now(),
+    val matches: List<Match> = emptyList(),
+    val teams: List<Team> = emptyList(),
+    val players: List<Player> = emptyList(),
+)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,8 @@
 spring:
   application:
     name: ultistats
+
+ultistats:
+  persistence:
+    path: ./data/ultistats.json
+    interval: 30000

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/persistence/JsonPersistenceServiceTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/persistence/JsonPersistenceServiceTest.kt
@@ -1,0 +1,113 @@
+package com.github.mihanizzm.ultistats.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.model.events.EventType
+import com.github.mihanizzm.ultistats.model.events.OnePlayerEvent
+import com.github.mihanizzm.ultistats.model.events.SystemEvent
+import com.github.mihanizzm.ultistats.model.events.TeamEvent
+import com.github.mihanizzm.ultistats.model.events.TwoPlayerEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+import java.util.UUID
+
+@SpringBootTest
+@Suppress("NonAsciiCharacters")
+class JsonPersistenceServiceTest {
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    companion object {
+        val TEAM_1_ID: UUID = UUID.fromString("0306caac-acd3-4b0a-9c58-000000000000")
+        val TEAM_2_ID: UUID = UUID.fromString("0306caac-acd3-4b0a-9c58-000000000001")
+        val PLAYER_1_ID: UUID = UUID.fromString("0306caac-acd3-4b0a-9c58-000000000002")
+        val PLAYER_2_ID: UUID = UUID.fromString("0306caac-acd3-4b0a-9c58-000000000003")
+        val MATCH_ID: UUID = UUID.fromString("0306caac-acd3-4b0a-9c58-000000000004")
+    }
+
+    @Test
+    fun `сериализация и десериализация PersistenceData`() {
+        val player1 = Player(PLAYER_1_ID, TEAM_1_ID, 22, "Михаил", "Сартаков")
+        val player2 = Player(PLAYER_2_ID, TEAM_2_ID, 11, "Денис", "Братчиков")
+
+        val team1 = Team(TEAM_1_ID, "НИИ ТУДА", listOf(PLAYER_1_ID))
+        val team2 = Team(TEAM_2_ID, "НИИ СЮДА", listOf(PLAYER_2_ID))
+
+        val timestamp = Instant.parse("2025-01-01T12:00:00Z")
+
+        val match = Match(
+            id = MATCH_ID,
+            teams = listOf(team1, team2),
+            events = mutableListOf(
+                OnePlayerEvent(PLAYER_1_ID, TEAM_1_ID, timestamp, EventType.PULL),
+                TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp.plusSeconds(10), EventType.GOAL),
+            ),
+        )
+
+        val data = PersistenceData(
+            version = 1,
+            savedAt = timestamp,
+            matches = listOf(match),
+            teams = listOf(team1, team2),
+            players = listOf(player1, player2),
+        )
+
+        val json = objectMapper.writeValueAsString(data)
+        val restored = objectMapper.readValue(json, PersistenceData::class.java)
+
+        assertEquals(data.version, restored.version)
+        assertEquals(data.savedAt, restored.savedAt)
+        assertEquals(data.matches.size, restored.matches.size)
+        assertEquals(data.teams.size, restored.teams.size)
+        assertEquals(data.players.size, restored.players.size)
+
+        assertEquals(data.matches[0].id, restored.matches[0].id)
+        assertEquals(data.matches[0].events.size, restored.matches[0].events.size)
+    }
+
+    @Test
+    fun `сериализация всех типов событий`() {
+        val timestamp = Instant.parse("2025-01-01T12:00:00Z")
+
+        val events = listOf(
+            OnePlayerEvent(PLAYER_1_ID, TEAM_1_ID, timestamp, EventType.PULL),
+            OnePlayerEvent(PLAYER_1_ID, TEAM_1_ID, timestamp, EventType.BRICK),
+            OnePlayerEvent(PLAYER_1_ID, TEAM_1_ID, timestamp, EventType.DROP),
+            OnePlayerEvent(PLAYER_1_ID, TEAM_1_ID, timestamp, EventType.TURNOVER),
+            TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp, EventType.PASS),
+            TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp, EventType.GOAL),
+            TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp, EventType.BLOCK_MARKER),
+            TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp, EventType.BLOCK_FIELD),
+            TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp, EventType.INTERCEPTION),
+            TwoPlayerEvent(PLAYER_1_ID, PLAYER_2_ID, TEAM_1_ID, TEAM_2_ID, timestamp, EventType.CALLAHAN),
+            TeamEvent(TEAM_1_ID, timestamp, EventType.TIMEOUT_START),
+            TeamEvent(TEAM_1_ID, timestamp, EventType.TIMEOUT_END),
+            SystemEvent(timestamp, EventType.HALFTIME_START),
+            SystemEvent(timestamp, EventType.HALFTIME_END),
+        )
+
+        val match = Match(
+            id = MATCH_ID,
+            teams = listOf(Team(TEAM_1_ID, "Team1", emptyList()), Team(TEAM_2_ID, "Team2", emptyList())),
+            events = events.toMutableList(),
+        )
+
+        val data = PersistenceData(matches = listOf(match))
+
+        val json = objectMapper.writeValueAsString(data)
+        val restored = objectMapper.readValue(json, PersistenceData::class.java)
+
+        assertEquals(events.size, restored.matches[0].events.size)
+
+        restored.matches[0].events.forEachIndexed { index, event ->
+            assertEquals(events[index].type, event.type)
+            assertEquals(events[index].realTimestamp, event.realTimestamp)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Реализовано периодическое автосохранение данных в JSON файл (каждые 30 сек)
- Данные загружаются при старте приложения
- Поддержка полиморфной сериализации Event через Jackson аннотации

## Изменения
- `config/JacksonConfig.kt` — настройка ObjectMapper с JavaTimeModule и KotlinModule
- `persistence/PersistenceData.kt` — модель данных для сохранения
- `persistence/JsonPersistenceService.kt` — сервис автосохранения
- `model/events/Event.kt` — добавлены @JsonTypeInfo и @JsonSubTypes
- `model/Match.kt` — добавлен @JsonIgnore для computed property status
- `application.yaml` — конфигурация пути и интервала

## Конфигурация
```yaml
ultistats:
  persistence:
    path: ./data/ultistats.json  # путь к файлу
    interval: 30000              # интервал в мс
```

## Test plan
- [x] Все 96 тестов проходят
- [x] Тесты сериализации/десериализации всех типов событий
- [ ] Проверить загрузку данных при рестарте приложения

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)