### PR TITLE
Добавить фото игрока

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
@@ -5,14 +5,17 @@ import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
 import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
 import com.github.mihanizzm.ultistats.dto.response.PlayerResponse
 import com.github.mihanizzm.ultistats.facade.PlayerFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @RestController
@@ -78,4 +81,28 @@ class PlayerController(
     fun delete(@PathVariable id: UUID): ResponseEntity<Unit> =
         if (playerFacade.delete(id)) ResponseEntity.noContent().build()
         else ResponseEntity.notFound().build()
+
+    @PostMapping("/{playerId}/uploadPhoto", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @Operation(summary = "Загрузить аватар для игрока")
+    fun uploadPhoto(
+        @PathVariable playerId: UUID,
+        @RequestBody multipartFile: MultipartFile,
+    ): ResponseEntity<PhotoUrlResponse> =
+        playerFacade.uploadPhoto(playerId, multipartFile)
+            ?.let { ResponseEntity.status(HttpStatus.CREATED).body(it) }
+            ?: ResponseEntity.notFound().build()
+
+    @GetMapping("/{playerId}/photoUrl")
+    @Operation(summary = "Получить URL изображения игрока")
+    fun getPhotoUrl(@PathVariable playerId: UUID): ResponseEntity<PhotoUrlResponse> =
+        playerFacade.getPhotoUrl(playerId)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
+
+    @DeleteMapping("/{playerId}/photoUrl")
+    @Operation(summary = "Удалить URL изображения игрока")
+    fun removePhotoUrl(@PathVariable playerId: UUID): ResponseEntity<PhotoUrlResponse> =
+        playerFacade.deletePhotoUrl(playerId)
+            ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/PlayerResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/PlayerResponse.kt
@@ -9,6 +9,7 @@ data class PlayerResponse(
     val number: Int?,
     val firstName: String,
     val lastName: String,
+    val photoUrl: String?,
 ) {
     companion object {
         fun from(player: Player) = PlayerResponse(
@@ -17,6 +18,7 @@ data class PlayerResponse(
             number = player.number,
             firstName = player.firstName,
             lastName = player.lastName,
+            photoUrl = player.photoUrl,
         )
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
@@ -5,18 +5,22 @@ import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
 import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdatePlayerRequest
+import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
 import com.github.mihanizzm.ultistats.dto.response.PlayerResponse
 import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.service.LocalFileStorageService
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
 import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
 import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @Component
 class PlayerFacade(
     private val playerService: PlayerService,
     private val teamService: TeamService,
+    private val localFileStorageService: LocalFileStorageService,
 ) {
     companion object {
         val DEFAULT_SORT = SortParam("lastName")
@@ -128,5 +132,27 @@ class PlayerFacade(
 
         playerService.delete(id)
         return true
+    }
+
+    fun uploadPhoto(playerId: UUID, file: MultipartFile): PhotoUrlResponse? {
+        val player = playerService.get(playerId) ?: return null
+        val url = localFileStorageService.upload(file) ?: return null
+
+        val updatedPlayer = player.copy(photoUrl = url)
+        playerService.update(updatedPlayer)
+        return PhotoUrlResponse(url)
+    }
+
+    fun getPhotoUrl(playerId: UUID): PhotoUrlResponse? {
+        val url = playerService.get(playerId)?.photoUrl ?: return null
+        return PhotoUrlResponse(url)
+    }
+
+    fun deletePhotoUrl(playerId: UUID): PhotoUrlResponse? {
+        val player = playerService.get(playerId) ?: return null
+        val url = player.photoUrl ?: return PhotoUrlResponse(null)
+        val updatedPlayer = player.copy(photoUrl = null)
+        playerService.update(updatedPlayer)
+        return PhotoUrlResponse(url)
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Player.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Player.kt
@@ -8,6 +8,7 @@ data class Player(
     val number: Int?,
     val firstName: String,
     val lastName: String,
+    val photoUrl: String? = null,
 ) {
     companion object {
         fun unknown(teamId: UUID) = Player(

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/MatchAbstractTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/MatchAbstractTest.kt
@@ -143,7 +143,7 @@ abstract class MatchAbstractTest {
             UUIDS[12],
             listOf(TEAM_1.id, TEAM_2.id),
             mutableListOf<Event>(),
-        )
+        ).apply { initTeamScores() }
     }
 
     @BeforeEach

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
@@ -284,6 +284,7 @@ class EventControllerTest {
             id = UUID.randomUUID(),
             teamIds = listOf(team1.id, team2.id),
         )
+        match.initTeamScores()
         matchService.create(match)
         return match
     }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -162,6 +162,7 @@ class StatisticsControllerTest {
             id = UUID.randomUUID(),
             teamIds = listOf(team1.id, team2.id),
         )
+        match.initTeamScores()
         matchService.create(match)
         return match
     }


### PR DESCRIPTION
## Summary
- Добавлено поле `photoUrl` в модель `Player` и `PlayerResponse`
- Добавлены эндпоинты для работы с фото игрока:
  - `POST /api/v1/players/{playerId}/uploadPhoto` — загрузить фото
  - `GET /api/v1/players/{playerId}/photoUrl` — получить URL фото
  - `DELETE /api/v1/players/{playerId}/photoUrl` — удалить фото
- Исправлены падающие тесты (добавлен `initTeamScores()` в тестовые фикстуры)

Closes #50

## Test plan
- [ ] Проверить загрузку фото через Swagger UI
- [ ] Проверить получение URL фото
- [ ] Проверить удаление фото
- [ ] Убедиться, что `photoUrl` возвращается в `PlayerResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)