### PR TITLE
Добавить List/Detail DTO для команд и матчей

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/MatchController.kt
@@ -6,6 +6,7 @@ import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
 import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdateMatchRequest
+import com.github.mihanizzm.ultistats.dto.response.MatchListItemResponse
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
 import com.github.mihanizzm.ultistats.facade.MatchFacade
 import com.github.mihanizzm.ultistats.model.MatchStatus
@@ -59,7 +60,7 @@ class MatchController(
         )
         @RequestParam(required = false)
         sort: SortParam?,
-    ): PageResponse<MatchResponse> {
+    ): PageResponse<MatchListItemResponse> {
         val filter = MatchFilterRequest(
             teamId = teamId,
             status = status,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -6,6 +6,8 @@ import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
 import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdateTeamRequest
 import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamDetailResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamListItemResponse
 import com.github.mihanizzm.ultistats.dto.response.TeamResponse
 import com.github.mihanizzm.ultistats.facade.TeamFacade
 import io.swagger.v3.oas.annotations.Operation
@@ -46,14 +48,14 @@ class TeamController(
         )
         @RequestParam(required = false)
         sort: SortParam?,
-    ): PageResponse<TeamResponse> {
+    ): PageResponse<TeamListItemResponse> {
         val filter = TeamFilterRequest(name = name)
         return teamFacade.getAllPaged(page, size, filter, sort ?: TeamFacade.DEFAULT_SORT)
     }
 
     @GetMapping("/{id}")
     @Operation(summary = "Получить команду по ID")
-    fun getById(@PathVariable id: UUID): ResponseEntity<TeamResponse> =
+    fun getById(@PathVariable id: UUID): ResponseEntity<TeamDetailResponse> =
         teamFacade.getById(id)
             ?.let { ResponseEntity.ok(it) }
             ?: ResponseEntity.notFound().build()

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchListItemResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchListItemResponse.kt
@@ -1,0 +1,39 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.MatchStatus
+import com.github.mihanizzm.ultistats.model.Team
+import java.time.Instant
+import java.util.UUID
+
+data class MatchListItemResponse(
+    val id: UUID,
+    val teams: List<MatchListTeamResponse>,
+    val plannedStartTimestamp: Instant?,
+    val startedAt: Instant?,
+    val endedAt: Instant?,
+    val status: MatchStatus,
+) {
+    companion object {
+        fun from(match: Match, teamsById: Map<UUID, Team>): MatchListItemResponse =
+            MatchListItemResponse(
+                id = match.id,
+                teams = match.teamIds.mapNotNull { teamId ->
+                    teamsById[teamId]?.let { team ->
+                        val teamScore = match.teamScores.find { it.teamId == teamId }?.score ?: 0
+                        MatchListTeamResponse(
+                            teamId = team.id,
+                            teamName = team.name,
+                            teamScore = teamScore,
+                            city = team.city,
+                            photoUrl = team.photoUrl,
+                        )
+                    }
+                },
+                plannedStartTimestamp = match.plannedStartTimestamp,
+                startedAt = match.startedAt,
+                endedAt = match.endedAt,
+                status = match.status,
+            )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchListTeamResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchListTeamResponse.kt
@@ -1,0 +1,11 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import java.util.UUID
+
+data class MatchListTeamResponse(
+    val teamId: UUID,
+    val teamName: String,
+    val teamScore: Int,
+    val city: String?,
+    val photoUrl: String?,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamDetailResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamDetailResponse.kt
@@ -1,0 +1,24 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.model.Team
+import java.util.UUID
+
+data class TeamDetailResponse(
+    val id: UUID,
+    val name: String,
+    val players: List<PlayerListItemResponse>,
+    val city: String?,
+    val photoUrl: String?,
+) {
+    companion object {
+        fun from(team: Team, players: List<Player>): TeamDetailResponse =
+            TeamDetailResponse(
+                id = team.id,
+                name = team.name,
+                players = players.map { PlayerListItemResponse.from(it, team) },
+                city = team.city,
+                photoUrl = team.photoUrl,
+            )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamListItemResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamListItemResponse.kt
@@ -1,0 +1,21 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.Team
+import java.util.UUID
+
+data class TeamListItemResponse(
+    val id: UUID,
+    val name: String,
+    val city: String?,
+    val photoUrl: String?,
+) {
+    companion object {
+        fun from(team: Team): TeamListItemResponse =
+            TeamListItemResponse(
+                id = team.id,
+                name = team.name,
+                city = team.city,
+                photoUrl = team.photoUrl,
+            )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
@@ -6,6 +6,7 @@ import com.github.mihanizzm.ultistats.dto.request.CreateMatchRequest
 import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.MatchTimestampRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdateMatchRequest
+import com.github.mihanizzm.ultistats.dto.response.MatchListItemResponse
 import com.github.mihanizzm.ultistats.dto.response.MatchResponse
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.service.MatchService
@@ -41,7 +42,7 @@ class MatchFacade(
         size: Int,
         filter: MatchFilterRequest,
         sortParam: SortParam = DEFAULT_SORT,
-    ): PageResponse<MatchResponse> {
+    ): PageResponse<MatchListItemResponse> {
         val filteredMatches = matchService.findAllFiltered(filter)
         val totalElements = filteredMatches.size.toLong()
 
@@ -52,7 +53,7 @@ class MatchFacade(
             .take(size)
             .map { match ->
                 val teams = teamService.getAllInList(match.teamIds)
-                MatchResponse.from(match, teams.associateBy { it.id })
+                MatchListItemResponse.from(match, teams.associateBy { it.id })
             }
 
         return PageResponse.of(content, totalElements, page, size)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
@@ -6,6 +6,8 @@ import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
 import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdateTeamRequest
 import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamDetailResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamListItemResponse
 import com.github.mihanizzm.ultistats.dto.response.TeamResponse
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.LocalFileStorageService
@@ -41,7 +43,7 @@ class TeamFacade(
         size: Int,
         filter: TeamFilterRequest,
         sortParam: SortParam = DEFAULT_SORT,
-    ): PageResponse<TeamResponse> {
+    ): PageResponse<TeamListItemResponse> {
         val filteredTeams = teamService.findAllFiltered(filter)
         val totalElements = filteredTeams.size.toLong()
 
@@ -50,18 +52,15 @@ class TeamFacade(
         val content = sortedTeams
             .drop(page * size)
             .take(size)
-            .map { team ->
-                val players = playerService.getAllByIds(team.playerIds)
-                TeamResponse.from(team, players)
-            }
+            .map { TeamListItemResponse.from(it) }
 
         return PageResponse.of(content, totalElements, page, size)
     }
 
-    fun getById(id: UUID): TeamResponse? {
+    fun getById(id: UUID): TeamDetailResponse? {
         val team = teamService.get(id) ?: return null
         val players = playerService.getAllByIds(team.playerIds)
-        return TeamResponse.from(team, players)
+        return TeamDetailResponse.from(team, players)
     }
 
     fun create(request: CreateTeamRequest): TeamResponse {


### PR DESCRIPTION
## Summary
- Добавлен `TeamListItemResponse` (id, name, city, photoUrl) для списка команд
- Добавлен `TeamDetailResponse` с полными данными и игроками как `PlayerListItemResponse`
- Добавлен `MatchListItemResponse` без playerIds в командах
- Добавлен `MatchListTeamResponse` — упрощённый DTO команды для списка матчей

Closes #54

## Test plan
- [x] Все существующие тесты проходят
- [ ] Проверить GET /api/v1/teams - должен возвращать TeamListItemResponse
- [ ] Проверить GET /api/v1/teams/{id} - должен возвращать TeamDetailResponse с игроками
- [ ] Проверить GET /api/v1/matches - должен возвращать MatchListItemResponse без playerIds

🤖 Generated with [Claude Code](https://claude.com/claude-code)