### PR TITLE
Добавить метод update в TeamService и MatchService

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/MatchFacade.kt
@@ -94,8 +94,7 @@ class MatchFacade(
             teamIds = newTeamIds,
             plannedStartTimestamp = request.plannedStartTimestamp ?: existingMatch.plannedStartTimestamp,
         )
-        matchService.delete(id)
-        matchService.create(updatedMatch)
+        matchService.update(updatedMatch)
         return MatchResponse.from(updatedMatch, teamsById)
     }
 

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
@@ -78,8 +78,7 @@ class PlayerFacade(
         request.teamId?.let { teamId ->
             teamService.get(teamId)?.let { team ->
                 val updatedTeam = team.copy(playerIds = team.playerIds + playerId)
-                teamService.delete(teamId)
-                teamService.create(updatedTeam)
+                teamService.update(updatedTeam)
             }
         }
 
@@ -107,15 +106,13 @@ class PlayerFacade(
             oldTeamId?.let { oldId ->
                 teamService.get(oldId)?.let { oldTeam ->
                     val updated = oldTeam.copy(playerIds = oldTeam.playerIds - id)
-                    teamService.delete(oldId)
-                    teamService.create(updated)
+                    teamService.update(updated)
                 }
             }
             newTeamId?.let { newId ->
                 teamService.get(newId)?.let { newTeam ->
                     val updated = newTeam.copy(playerIds = newTeam.playerIds + id)
-                    teamService.delete(newId)
-                    teamService.create(updated)
+                    teamService.update(updated)
                 }
             }
         }
@@ -129,8 +126,7 @@ class PlayerFacade(
         player.teamId?.let { teamId ->
             teamService.get(teamId)?.let { team ->
                 val updatedTeam = team.copy(playerIds = team.playerIds - id)
-                teamService.delete(teamId)
-                teamService.create(updatedTeam)
+                teamService.update(updatedTeam)
             }
         }
 

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
@@ -110,8 +110,7 @@ class TeamFacade(
             playerIds = newPlayerIds,
             city = request.city ?: existingTeam.city,
         )
-        teamService.delete(id)
-        teamService.create(updatedTeam)
+        teamService.update(updatedTeam)
 
         val players = playerService.getAllByIds(newPlayerIds)
         return TeamResponse.from(updatedTeam, players)
@@ -143,8 +142,7 @@ class TeamFacade(
             if (oldTeamId != teamId) {
                 teamService.get(oldTeamId)?.let { oldTeam ->
                     val updatedOldTeam = oldTeam.copy(playerIds = oldTeam.playerIds - playerId)
-                    teamService.delete(oldTeamId)
-                    teamService.create(updatedOldTeam)
+                    teamService.update(updatedOldTeam)
                 }
             }
         }
@@ -152,8 +150,7 @@ class TeamFacade(
         playerService.update(player.copy(teamId = teamId))
 
         val updatedTeam = team.copy(playerIds = team.playerIds + playerId)
-        teamService.delete(teamId)
-        teamService.create(updatedTeam)
+        teamService.update(updatedTeam)
 
         val players = playerService.getAllByIds(updatedTeam.playerIds)
         return TeamResponse.from(updatedTeam, players)
@@ -168,8 +165,7 @@ class TeamFacade(
         }
 
         val updatedTeam = team.copy(playerIds = team.playerIds - playerId)
-        teamService.delete(teamId)
-        teamService.create(updatedTeam)
+        teamService.update(updatedTeam)
 
         val players = playerService.getAllByIds(updatedTeam.playerIds)
         return TeamResponse.from(updatedTeam, players)
@@ -180,8 +176,7 @@ class TeamFacade(
         val url = localFileStorageService.upload(file) ?: return null
 
         val newTeam = team.copy(photoUrl = url)
-        teamService.delete(team.id)
-        teamService.create(newTeam)
+        teamService.update(newTeam)
         return PhotoUrlResponse(url)
     }
 
@@ -194,8 +189,7 @@ class TeamFacade(
         val team = teamService.get(teamId) ?: return null
         val url = team.photoUrl ?: return PhotoUrlResponse(null)
         val newTeam = team.copy(photoUrl = null)
-        teamService.delete(team.id)
-        teamService.create(newTeam)
+        teamService.update(newTeam)
         return PhotoUrlResponse(url)
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchService.kt
@@ -12,6 +12,8 @@ interface MatchService {
 
     fun create(match: Match)
 
+    fun update(match: Match)
+
     fun delete(matchId: UUID)
 
     fun getAll(): List<Match>

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
@@ -23,6 +23,8 @@ class MatchServiceImpl(
 
     override fun create(match: Match) = matchRepository.save(match)
 
+    override fun update(match: Match) = matchRepository.save(match)
+
     override fun delete(matchId: UUID) = matchRepository.delete(matchId)
 
     override fun getAll(): List<Match> = matchRepository.getAll()

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamService.kt
@@ -9,6 +9,8 @@ interface TeamService {
 
     fun create(team: Team)
 
+    fun update(team: Team)
+
     fun delete(teamId: UUID)
 
     fun getAll(): List<Team>

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamServiceImpl.kt
@@ -17,6 +17,8 @@ class TeamServiceImpl(
 
     override fun create(team: Team) = teamRepository.save(team)
 
+    override fun update(team: Team) = teamRepository.save(team)
+
     override fun delete(teamId: UUID) = teamRepository.delete(teamId)
 
     override fun getAll(): List<Team> = teamRepository.getAll()


### PR DESCRIPTION
## Summary
- Добавлен метод `update()` в интерфейсы `TeamService` и `MatchService`
- Реализация `update()` в `TeamServiceImpl` и `MatchServiceImpl` — просто вызов `repository.save()`
- Заменены все `delete()` + `create()` на `update()` в фасадах

## Motivation
Подготовка к миграции на СУБД — при переходе достаточно будет изменить реализацию `update()` в сервисах, не трогая фасады.

Closes #57

## Test plan
- [x] Все существующие тесты проходят

🤖 Generated with [Claude Code](https://claude.com/claude-code)