### PR TITLE
feat: PostgreSQL support with Spring profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,47 @@
 
 ---
 
-## Быстрый старт (Docker)
+## Быстрый старт
 
-Самый простой способ запустить приложение — через Docker:
+### Вариант 1: In-memory (без БД)
+
+Самый быстрый способ для разработки и демо — данные хранятся в памяти:
 
 ```bash
 # Клонировать репозиторий
 git clone https://github.com/UltiStatsDev/ultistats-backend.git
 cd ultistats-backend
 
-# Запустить через docker-compose
+# Запустить
+./gradlew bootRun
+```
+
+### Вариант 2: С PostgreSQL
+
+Для продакшн-подобного окружения с персистентным хранилищем:
+
+```bash
+# Запустить PostgreSQL
+docker run -d --name ultistats-postgres \
+  -e POSTGRES_DB=ultistats \
+  -e POSTGRES_USER=ultistats \
+  -e POSTGRES_PASSWORD=ultistats \
+  -p 5432:5432 \
+  -v ultistats_postgres_data:/var/lib/postgresql/data \
+  postgres:16-alpine
+
+# Запустить приложение с профилем postgres
+./gradlew bootRun --args='--spring.profiles.active=postgres'
+```
+
+### Вариант 3: Docker Compose (всё вместе)
+
+```bash
+# In-memory режим (по умолчанию)
 docker-compose up -d
 
-# Или собрать и запустить вручную
-docker build -t ultistats .
-docker run -p 8080:8080 ultistats
+# С PostgreSQL
+SPRING_PROFILES_ACTIVE=postgres docker-compose up -d
 ```
 
 После запуска:
@@ -29,7 +55,43 @@ docker run -p 8080:8080 ultistats
 Остановка:
 ```bash
 docker-compose down
+# Или остановить только postgres контейнер
+docker stop ultistats-postgres
 ```
+
+---
+
+## Профили приложения
+
+Приложение поддерживает два профиля для разных сценариев использования:
+
+| Профиль | Хранилище | Описание |
+|---------|-----------|----------|
+| `default` / `inmemory` | In-memory (ConcurrentHashMap) | Быстрый старт, данные теряются при перезапуске |
+| `postgres` | PostgreSQL | Персистентное хранение, миграции через Flyway |
+
+### Переключение профилей
+
+**Через аргументы:**
+```bash
+./gradlew bootRun --args='--spring.profiles.active=postgres'
+```
+
+**Через переменную окружения:**
+```bash
+export SPRING_PROFILES_ACTIVE=postgres
+./gradlew bootRun
+```
+
+### Настройка PostgreSQL
+
+При использовании профиля `postgres` можно настроить подключение через переменные окружения:
+
+| Переменная | По умолчанию | Описание |
+|------------|--------------|----------|
+| `DATABASE_URL` | `jdbc:postgresql://localhost:5432/ultistats` | JDBC URL |
+| `DATABASE_USERNAME` | `ultistats` | Имя пользователя |
+| `DATABASE_PASSWORD` | `ultistats` | Пароль |
 
 ---
 
@@ -62,10 +124,12 @@ docker-compose down
 
 ## Технологический стек
 
-- **Backend:** Kotlin, Spring Boot, Gradle
+- **Backend:** Kotlin, Spring Boot 3, Gradle
+- **Persistence:** Spring Data JPA, PostgreSQL, Flyway (миграции)
 - **Тесты:** JUnit 5, MockK, AssertJ, SpringMockMvc
 - **Документация API:** springdoc-openapi (Swagger UI)
 - **Логирование:** Logback
+- **Контейнеризация:** Docker, Docker Compose
 - **Frontend:** ReactJS (реализация отдельно)
 - **Форматы обмена:** JSON (основной), в перспективе — CSV для табличных статистик
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	kotlin("jvm") version "1.9.25"
 	kotlin("plugin.spring") version "1.9.25"
+	kotlin("plugin.jpa") version "1.9.25"
 	id("org.springframework.boot") version "3.5.7"
 	id("io.spring.dependency-management") version "1.1.7"
 }
@@ -27,9 +28,13 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+	implementation("org.flywaydb:flyway-core")
+	implementation("org.flywaydb:flyway-database-postgresql")
+	runtimeOnly("org.postgresql:postgresql")
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,31 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SPRING_PROFILES_ACTIVE=default
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-default}
+      - DATABASE_URL=jdbc:postgresql://postgres:5432/ultistats
+      - DATABASE_USERNAME=ultistats
+      - DATABASE_PASSWORD=ultistats
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: ultistats-postgres
+    environment:
+      POSTGRES_DB: ultistats
+      POSTGRES_USER: ultistats
+      POSTGRES_PASSWORD: ultistats
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ultistats -d ultistats"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/entity/MatchEntity.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/entity/MatchEntity.kt
@@ -1,0 +1,41 @@
+package com.github.mihanizzm.ultistats.repository.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "matches")
+class MatchEntity(
+    @Id
+    val id: UUID,
+
+    @Column(name = "team_ids", nullable = false, columnDefinition = "uuid[]")
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    var teamIds: Array<UUID>,
+
+    @Column(name = "events", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    var eventsJson: String = "[]",
+
+    @Column(name = "team_scores", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    var teamScoresJson: String = "[]",
+
+    @Column(name = "disk_holder_id")
+    var diskHolderId: UUID? = null,
+
+    @Column(name = "planned_start_timestamp")
+    var plannedStartTimestamp: Instant? = null,
+
+    @Column(name = "started_at")
+    var startedAt: Instant? = null,
+
+    @Column(name = "ended_at")
+    var endedAt: Instant? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/entity/PlayerEntity.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/entity/PlayerEntity.kt
@@ -1,0 +1,29 @@
+package com.github.mihanizzm.ultistats.repository.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "players")
+class PlayerEntity(
+    @Id
+    val id: UUID,
+
+    @Column(name = "team_id")
+    var teamId: UUID?,
+
+    @Column
+    var number: Int? = null,
+
+    @Column(name = "first_name", nullable = false)
+    var firstName: String,
+
+    @Column(name = "last_name", nullable = false)
+    var lastName: String,
+
+    @Column(name = "photo_url")
+    var photoUrl: String? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/entity/TeamEntity.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/entity/TeamEntity.kt
@@ -1,0 +1,23 @@
+package com.github.mihanizzm.ultistats.repository.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "teams")
+class TeamEntity(
+    @Id
+    val id: UUID,
+
+    @Column(nullable = false)
+    var name: String,
+
+    @Column
+    var city: String? = null,
+
+    @Column(name = "photo_url")
+    var photoUrl: String? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/inmemory/InMemoryMatchRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/inmemory/InMemoryMatchRepository.kt
@@ -1,14 +1,16 @@
-package com.github.mihanizzm.ultistats.service
+package com.github.mihanizzm.ultistats.repository.inmemory
 
 import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
 import com.github.mihanizzm.ultistats.model.Match
-import org.springframework.stereotype.Service
+import com.github.mihanizzm.ultistats.service.MatchRepository
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Repository
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
-@Service
-@Suppress("unused")
-class MatchRepositoryConcurrentMapImpl : MatchRepository {
+@Repository
+@Profile("inmemory", "default")
+class InMemoryMatchRepository : MatchRepository {
     private val matches = ConcurrentHashMap<UUID, Match>()
 
     override fun get(id: UUID): Match? = matches[id]

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/inmemory/InMemoryPlayerRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/inmemory/InMemoryPlayerRepository.kt
@@ -1,13 +1,16 @@
-package com.github.mihanizzm.ultistats.service
+package com.github.mihanizzm.ultistats.repository.inmemory
 
 import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
 import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.service.PlayerRepository
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Repository
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 @Repository
-class PlayerRepositoryConcurrentMapImpl : PlayerRepository {
+@Profile("inmemory", "default")
+class InMemoryPlayerRepository : PlayerRepository {
     private val players = ConcurrentHashMap<UUID, Player>()
 
     override fun get(id: UUID): Player? = players[id]

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/inmemory/InMemoryTeamRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/inmemory/InMemoryTeamRepository.kt
@@ -1,14 +1,16 @@
-package com.github.mihanizzm.ultistats.service
+package com.github.mihanizzm.ultistats.repository.inmemory
 
 import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.model.Team
-import org.springframework.stereotype.Service
+import com.github.mihanizzm.ultistats.service.TeamRepository
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Repository
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
-@Service
-@Suppress("unused")
-class TeamRepositoryConcurrentMapImpl : TeamRepository {
+@Repository
+@Profile("inmemory", "default")
+class InMemoryTeamRepository : TeamRepository {
     private val teams = ConcurrentHashMap<UUID, Team>()
 
     override fun get(id: UUID): Team? = teams[id]

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaMatchRepositoryAdapter.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaMatchRepositoryAdapter.kt
@@ -1,0 +1,97 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.github.mihanizzm.ultistats.dto.request.MatchFilterRequest
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.MatchStatus
+import com.github.mihanizzm.ultistats.repository.entity.MatchEntity
+import com.github.mihanizzm.ultistats.repository.mapper.MatchMapper
+import com.github.mihanizzm.ultistats.service.MatchRepository
+import jakarta.persistence.criteria.Predicate
+import org.springframework.context.annotation.Profile
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+@Profile("postgres")
+class JpaMatchRepositoryAdapter(
+    private val springDataMatchRepository: SpringDataMatchRepository,
+    private val matchMapper: MatchMapper,
+) : MatchRepository {
+
+    override fun get(id: UUID): Match? =
+        springDataMatchRepository.findByIdOrNull(id)?.let { matchMapper.toDomain(it) }
+
+    override fun save(match: Match) {
+        springDataMatchRepository.save(matchMapper.toEntity(match))
+    }
+
+    override fun delete(id: UUID) {
+        springDataMatchRepository.deleteById(id)
+    }
+
+    override fun getAll(): List<Match> =
+        springDataMatchRepository.findAll().map { matchMapper.toDomain(it) }
+
+    override fun findAllFiltered(filter: MatchFilterRequest): List<Match> {
+        val spec = buildSpecification(filter)
+        return springDataMatchRepository.findAll(spec).map { matchMapper.toDomain(it) }
+    }
+
+    override fun count(): Long = springDataMatchRepository.count()
+
+    override fun countFiltered(filter: MatchFilterRequest): Long {
+        val spec = buildSpecification(filter)
+        return springDataMatchRepository.count(spec)
+    }
+
+    private fun buildSpecification(filter: MatchFilterRequest): Specification<MatchEntity> {
+        return Specification { root, _, criteriaBuilder ->
+            val predicates = mutableListOf<Predicate>()
+
+            filter.teamId?.let { teamId ->
+                // PostgreSQL array contains: team_ids @> ARRAY[teamId]
+                val teamIdArray = criteriaBuilder.function(
+                    "array_position",
+                    Int::class.java,
+                    root.get<Array<UUID>>("teamIds"),
+                    criteriaBuilder.literal(teamId)
+                )
+                predicates.add(criteriaBuilder.isNotNull(teamIdArray))
+            }
+
+            filter.status?.let { status ->
+                when (status) {
+                    MatchStatus.FINISHED -> predicates.add(criteriaBuilder.isNotNull(root.get<Any>("endedAt")))
+                    MatchStatus.IN_PROGRESS -> {
+                        predicates.add(criteriaBuilder.isNotNull(root.get<Any>("startedAt")))
+                        predicates.add(criteriaBuilder.isNull(root.get<Any>("endedAt")))
+                    }
+                    MatchStatus.PLANNED -> {
+                        predicates.add(criteriaBuilder.isNull(root.get<Any>("startedAt")))
+                        predicates.add(criteriaBuilder.isNull(root.get<Any>("endedAt")))
+                    }
+                }
+            }
+
+            filter.dateFrom?.let { dateFrom ->
+                val dateField = criteriaBuilder.coalesce<java.time.Instant>(
+                    root.get("startedAt"),
+                    root.get("plannedStartTimestamp")
+                )
+                predicates.add(criteriaBuilder.greaterThanOrEqualTo(dateField, dateFrom))
+            }
+
+            filter.dateTo?.let { dateTo ->
+                val dateField = criteriaBuilder.coalesce<java.time.Instant>(
+                    root.get("startedAt"),
+                    root.get("plannedStartTimestamp")
+                )
+                predicates.add(criteriaBuilder.lessThanOrEqualTo(dateField, dateTo))
+            }
+
+            criteriaBuilder.and(*predicates.toTypedArray())
+        }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaPlayerRepositoryAdapter.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaPlayerRepositoryAdapter.kt
@@ -1,0 +1,46 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.github.mihanizzm.ultistats.dto.request.PlayerFilterRequest
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.repository.mapper.toDomain
+import com.github.mihanizzm.ultistats.repository.mapper.toEntity
+import com.github.mihanizzm.ultistats.service.PlayerRepository
+import org.springframework.context.annotation.Profile
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+@Profile("postgres")
+class JpaPlayerRepositoryAdapter(
+    private val springDataPlayerRepository: SpringDataPlayerRepository,
+) : PlayerRepository {
+
+    override fun get(id: UUID): Player? =
+        springDataPlayerRepository.findByIdOrNull(id)?.toDomain()
+
+    override fun save(player: Player) {
+        springDataPlayerRepository.save(player.toEntity())
+    }
+
+    override fun delete(id: UUID) {
+        springDataPlayerRepository.deleteById(id)
+    }
+
+    override fun getAll(): List<Player> =
+        springDataPlayerRepository.findAll().map { it.toDomain() }
+
+    override fun getAllByIds(ids: List<UUID>): List<Player> =
+        springDataPlayerRepository.findAllByIdIn(ids).map { it.toDomain() }
+
+    override fun getAllByTeamId(teamId: UUID): List<Player> =
+        springDataPlayerRepository.findAllByTeamId(teamId).map { it.toDomain() }
+
+    override fun findAllFiltered(filter: PlayerFilterRequest): List<Player> =
+        springDataPlayerRepository.findFiltered(filter.teamId, filter.name).map { it.toDomain() }
+
+    override fun count(): Long = springDataPlayerRepository.count()
+
+    override fun countFiltered(filter: PlayerFilterRequest): Long =
+        springDataPlayerRepository.countFiltered(filter.teamId, filter.name)
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaRepositoryConfig.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaRepositoryConfig.kt
@@ -1,0 +1,15 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.mihanizzm.ultistats.repository.mapper.MatchMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("postgres")
+class JpaRepositoryConfig {
+
+    @Bean
+    fun matchMapper(objectMapper: ObjectMapper): MatchMapper = MatchMapper(objectMapper)
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaTeamRepositoryAdapter.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/JpaTeamRepositoryAdapter.kt
@@ -1,0 +1,69 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.repository.mapper.toDomain
+import com.github.mihanizzm.ultistats.repository.mapper.toEntity
+import com.github.mihanizzm.ultistats.service.TeamRepository
+import org.springframework.context.annotation.Profile
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+@Profile("postgres")
+class JpaTeamRepositoryAdapter(
+    private val springDataTeamRepository: SpringDataTeamRepository,
+    private val springDataPlayerRepository: SpringDataPlayerRepository,
+) : TeamRepository {
+
+    override fun get(id: UUID): Team? {
+        val entity = springDataTeamRepository.findByIdOrNull(id) ?: return null
+        val playerIds = springDataPlayerRepository.findAllByTeamId(id).map { it.id }
+        return entity.toDomain(playerIds)
+    }
+
+    override fun save(team: Team) {
+        springDataTeamRepository.save(team.toEntity())
+    }
+
+    override fun delete(id: UUID) {
+        springDataTeamRepository.deleteById(id)
+    }
+
+    override fun getAll(): List<Team> {
+        return springDataTeamRepository.findAll().map { entity ->
+            val playerIds = springDataPlayerRepository.findAllByTeamId(entity.id).map { it.id }
+            entity.toDomain(playerIds)
+        }
+    }
+
+    override fun getAllInList(ids: List<UUID>): List<Team> {
+        return springDataTeamRepository.findAllByIdIn(ids).map { entity ->
+            val playerIds = springDataPlayerRepository.findAllByTeamId(entity.id).map { it.id }
+            entity.toDomain(playerIds)
+        }
+    }
+
+    override fun findAllFiltered(filter: TeamFilterRequest): List<Team> {
+        val entities = if (filter.name != null) {
+            springDataTeamRepository.findByNameContainingIgnoreCase(filter.name)
+        } else {
+            springDataTeamRepository.findAll()
+        }
+        return entities.map { entity ->
+            val playerIds = springDataPlayerRepository.findAllByTeamId(entity.id).map { it.id }
+            entity.toDomain(playerIds)
+        }
+    }
+
+    override fun count(): Long = springDataTeamRepository.count()
+
+    override fun countFiltered(filter: TeamFilterRequest): Long {
+        return if (filter.name != null) {
+            springDataTeamRepository.countByNameContainingIgnoreCase(filter.name)
+        } else {
+            springDataTeamRepository.count()
+        }
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataMatchRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataMatchRepository.kt
@@ -1,0 +1,10 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.github.mihanizzm.ultistats.repository.entity.MatchEntity
+import org.springframework.context.annotation.Profile
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import java.util.UUID
+
+@Profile("postgres")
+interface SpringDataMatchRepository : JpaRepository<MatchEntity, UUID>, JpaSpecificationExecutor<MatchEntity>

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataPlayerRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataPlayerRepository.kt
@@ -1,0 +1,29 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.github.mihanizzm.ultistats.repository.entity.PlayerEntity
+import org.springframework.context.annotation.Profile
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.util.UUID
+
+@Profile("postgres")
+interface SpringDataPlayerRepository : JpaRepository<PlayerEntity, UUID> {
+
+    fun findAllByTeamId(teamId: UUID): List<PlayerEntity>
+
+    fun findAllByIdIn(ids: List<UUID>): List<PlayerEntity>
+
+    @Query("""
+        SELECT p FROM PlayerEntity p
+        WHERE (:teamId IS NULL OR p.teamId = :teamId)
+        AND (:name IS NULL OR LOWER(CONCAT(p.firstName, ' ', p.lastName)) LIKE LOWER(CONCAT('%', :name, '%')))
+    """)
+    fun findFiltered(teamId: UUID?, name: String?): List<PlayerEntity>
+
+    @Query("""
+        SELECT COUNT(p) FROM PlayerEntity p
+        WHERE (:teamId IS NULL OR p.teamId = :teamId)
+        AND (:name IS NULL OR LOWER(CONCAT(p.firstName, ' ', p.lastName)) LIKE LOWER(CONCAT('%', :name, '%')))
+    """)
+    fun countFiltered(teamId: UUID?, name: String?): Long
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataTeamRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataTeamRepository.kt
@@ -1,0 +1,19 @@
+package com.github.mihanizzm.ultistats.repository.jpa
+
+import com.github.mihanizzm.ultistats.repository.entity.TeamEntity
+import org.springframework.context.annotation.Profile
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.util.UUID
+
+@Profile("postgres")
+interface SpringDataTeamRepository : JpaRepository<TeamEntity, UUID> {
+
+    @Query("SELECT t FROM TeamEntity t WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :name, '%'))")
+    fun findByNameContainingIgnoreCase(name: String): List<TeamEntity>
+
+    @Query("SELECT COUNT(t) FROM TeamEntity t WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :name, '%'))")
+    fun countByNameContainingIgnoreCase(name: String): Long
+
+    fun findAllByIdIn(ids: List<UUID>): List<TeamEntity>
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/mapper/MatchMapper.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/mapper/MatchMapper.kt
@@ -1,0 +1,47 @@
+package com.github.mihanizzm.ultistats.repository.mapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.TeamScore
+import com.github.mihanizzm.ultistats.model.events.Event
+import com.github.mihanizzm.ultistats.repository.entity.MatchEntity
+
+class MatchMapper(private val objectMapper: ObjectMapper) {
+
+    fun toDomain(entity: MatchEntity): Match {
+        val events: MutableList<Event> = if (entity.eventsJson.isNotBlank() && entity.eventsJson != "[]") {
+            objectMapper.readValue(entity.eventsJson)
+        } else {
+            mutableListOf()
+        }
+
+        val teamScores: MutableList<TeamScore> = if (entity.teamScoresJson.isNotBlank() && entity.teamScoresJson != "[]") {
+            objectMapper.readValue(entity.teamScoresJson)
+        } else {
+            mutableListOf()
+        }
+
+        return Match(
+            id = entity.id,
+            teamIds = entity.teamIds.toList(),
+            events = events,
+            teamScores = teamScores,
+            diskHolderId = entity.diskHolderId,
+            plannedStartTimestamp = entity.plannedStartTimestamp,
+            startedAt = entity.startedAt,
+            endedAt = entity.endedAt,
+        )
+    }
+
+    fun toEntity(match: Match): MatchEntity = MatchEntity(
+        id = match.id,
+        teamIds = match.teamIds.toTypedArray(),
+        eventsJson = objectMapper.writeValueAsString(match.events),
+        teamScoresJson = objectMapper.writeValueAsString(match.teamScores),
+        diskHolderId = match.diskHolderId,
+        plannedStartTimestamp = match.plannedStartTimestamp,
+        startedAt = match.startedAt,
+        endedAt = match.endedAt,
+    )
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/mapper/PlayerMapper.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/mapper/PlayerMapper.kt
@@ -1,0 +1,22 @@
+package com.github.mihanizzm.ultistats.repository.mapper
+
+import com.github.mihanizzm.ultistats.model.Player
+import com.github.mihanizzm.ultistats.repository.entity.PlayerEntity
+
+fun PlayerEntity.toDomain(): Player = Player(
+    id = id,
+    teamId = teamId,
+    number = number,
+    firstName = firstName,
+    lastName = lastName,
+    photoUrl = photoUrl,
+)
+
+fun Player.toEntity(): PlayerEntity = PlayerEntity(
+    id = id,
+    teamId = teamId,
+    number = number,
+    firstName = firstName,
+    lastName = lastName,
+    photoUrl = photoUrl,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/mapper/TeamMapper.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/mapper/TeamMapper.kt
@@ -1,0 +1,19 @@
+package com.github.mihanizzm.ultistats.repository.mapper
+
+import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.repository.entity.TeamEntity
+
+fun TeamEntity.toDomain(playerIds: List<java.util.UUID>): Team = Team(
+    id = id,
+    name = name,
+    playerIds = playerIds,
+    city = city,
+    photoUrl = photoUrl,
+)
+
+fun Team.toEntity(): TeamEntity = TeamEntity(
+    id = id,
+    name = name,
+    city = city,
+    photoUrl = photoUrl,
+)

--- a/src/main/resources/application-postgres.yaml
+++ b/src/main/resources/application-postgres.yaml
@@ -1,0 +1,23 @@
+spring:
+  # Включаем JPA и Flyway для профиля postgres (убираем exclusions)
+  autoconfigure:
+    exclude: []
+
+  datasource:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/ultistats}
+    username: ${DATABASE_USERNAME:ultistats}
+    password: ${DATABASE_PASSWORD:ultistats}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,10 +1,18 @@
 spring:
   application:
     name: ultistats
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:default}
   servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+  # По умолчанию (без профиля postgres) отключаем JPA и Flyway
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 
 ultistats:
   persistence:

--- a/src/main/resources/db/migration/V1__create_tables.sql
+++ b/src/main/resources/db/migration/V1__create_tables.sql
@@ -1,0 +1,38 @@
+-- Таблица команд
+CREATE TABLE teams (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    city VARCHAR(255),
+    photo_url VARCHAR(1024)
+);
+
+-- Таблица игроков
+CREATE TABLE players (
+    id UUID PRIMARY KEY,
+    team_id UUID REFERENCES teams(id) ON DELETE SET NULL,
+    number INTEGER,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    photo_url VARCHAR(1024)
+);
+
+-- Индекс для быстрого поиска игроков по команде
+CREATE INDEX idx_players_team_id ON players(team_id);
+
+-- Таблица матчей
+CREATE TABLE matches (
+    id UUID PRIMARY KEY,
+    team_ids UUID[] NOT NULL,
+    events JSONB NOT NULL DEFAULT '[]',
+    team_scores JSONB NOT NULL DEFAULT '[]',
+    disk_holder_id UUID,
+    planned_start_timestamp TIMESTAMP WITH TIME ZONE,
+    started_at TIMESTAMP WITH TIME ZONE,
+    ended_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Индекс для поиска матчей по командам (GIN для массива)
+CREATE INDEX idx_matches_team_ids ON matches USING GIN(team_ids);
+
+-- Индекс для поиска матчей по дате начала
+CREATE INDEX idx_matches_started_at ON matches(started_at);


### PR DESCRIPTION
## Summary

Реализация issue #52 - добавлена поддержка PostgreSQL с сохранением in-memory реализации как fallback.

### Изменения:

- Добавлены зависимости Spring Data JPA, PostgreSQL driver, Flyway
- Созданы JPA entities (TeamEntity, PlayerEntity, MatchEntity)
- Создана Flyway миграция V1__create_tables.sql
- In-memory репозитории перенесены в `repository/inmemory/` с `@Profile("default", "inmemory")`
- Созданы JPA адаптеры с `@Profile("postgres")`
- Созданы Entity-to-Domain мапперы с JSON сериализацией для событий
- Обновлен application.yaml для отключения JPA по умолчанию
- Добавлен application-postgres.yaml для PostgreSQL профиля
- Обновлен docker-compose.yml с PostgreSQL сервисом
- Обновлен README.md с документацией по профилям

### Профили:

| Профиль | Хранилище | Описание |
|---------|-----------|----------|
| `default` / `inmemory` | In-memory (ConcurrentHashMap) | Быстрый старт, данные теряются при перезапуске |
| `postgres` | PostgreSQL | Персистентное хранение, миграции через Flyway |

### Быстрый старт с PostgreSQL:

```bash
# Запустить PostgreSQL
docker run -d --name ultistats-postgres \
  -e POSTGRES_DB=ultistats \
  -e POSTGRES_USER=ultistats \
  -e POSTGRES_PASSWORD=ultistats \
  -p 5432:5432 \
  postgres:16-alpine

# Запустить приложение
./gradlew bootRun --args='--spring.profiles.active=postgres'
```

## Test plan

- [x] Тесты проходят с in-memory профилем
- [x] Приложение запускается с postgres профилем
- [x] CRUD операции работают с PostgreSQL
- [x] Flyway миграции применяются корректно

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)