### PR TITLE
Revise membership and event APIs

### DIFF
--- a/ai/API_REVIEW_HANDOFF.md
+++ b/ai/API_REVIEW_HANDOFF.md
@@ -1,0 +1,153 @@
+# API review handoff after PR #75
+
+## Purpose
+
+This document records the controller/API audit performed after the explicit `TeamPlayer`
+and category-specific event API work in PR #75. It is intended as starting context for a
+future implementation session, not as a replacement for the linked GitHub issues.
+
+## Current state
+
+PR #75 introduces:
+
+- explicit team-player membership resources;
+- removal of membership state from `Player` and `Team` entities;
+- category-specific event request/response DTOs;
+- UUID-addressed events instead of list indexes;
+- immutable event type and `occurredAt`;
+- event chronology and match-snapshot participant validation.
+
+At the time of this handoff, `./gradlew test` passes on branch
+`feature/explicit-memberships-event-api`.
+
+## Recommended implementation order
+
+### 1. Request validation and error contract
+
+Existing issues:
+
+- #32 — validate sort, pagination, and filter parameters;
+- #30 — return meaningful, consistent validation errors.
+
+Implement these together if practical:
+
+- add Spring Validation and `@Valid`/`@Validated` at controller boundaries;
+- validate `page >= 0`, `1 <= size <= configured maximum`, date ranges, blank names,
+  player numbers, and empty patch requests;
+- reject unsupported sort fields rather than silently ignoring them;
+- introduce `@RestControllerAdvice` and Spring `ProblemDetail` responses;
+- use stable machine-readable error codes in addition to human-readable detail;
+- map domain/use-case errors rather than broadly catching persistence exceptions in controllers.
+
+Suggested error categories:
+
+- `RESOURCE_NOT_FOUND` -> 404;
+- `REQUEST_VALIDATION_FAILED` -> 400;
+- `INVALID_RESOURCE_STATE` -> 409;
+- `TEAM_NUMBER_CONFLICT` -> 409;
+- `EVENT_CHRONOLOGY_INVALID` -> 400 or 409, chosen and documented consistently;
+- storage/internal failures -> 5xx without leaking implementation details.
+
+### 2. Match lifecycle and response semantics
+
+New issue: #76 — <https://github.com/UltiStatsDev/ultistats-backend/issues/76>
+
+Important current defects:
+
+- `MatchFacade` uses `null` for both missing resources and invalid requests;
+- update maps invalid team changes to 404;
+- start/end map a missing match to 400;
+- start/end chronology is not checked against each other or existing events;
+- transition responses should be built from explicitly reloaded final state.
+
+Prefer a typed use-case result over nullable return values. Define and test the match state
+machine before changing the controller.
+
+### 3. Correct partial-update semantics
+
+New issue: #78 — <https://github.com/UltiStatsDev/ultistats-backend/issues/78>
+
+Current `PUT` methods for Player, Team, and Match are partial updates. Convert them to
+`PATCH` and decide how JSON distinguishes an omitted property from an explicit `null`.
+This is required to support clearing `Team.city` and `Match.plannedStartTimestamp`.
+
+Evaluate one of:
+
+- JSON Merge Patch (`application/merge-patch+json`);
+- presence-aware wrapper fields in Kotlin DTOs;
+- explicit commands for clearing individual values.
+
+Do not use ordinary nullable Kotlin properties alone: they collapse omitted and explicit null.
+
+### 4. Pagination implementation
+
+Existing issue: #63 — move pagination/sorting into the database layer.
+
+Issue #32 should first establish parameter validation and supported sort fields. Then #63
+can replace facade `drop/take` and in-memory sorting with repository `Pageable`/specifications.
+Preserve response contract tests while changing the implementation.
+
+### 5. Photo API and storage lifecycle
+
+Existing security issue: #64.
+
+New lifecycle/API issue: #77 — <https://github.com/UltiStatsDev/ultistats-backend/issues/77>
+
+Treat these as related but distinct scopes. Recommended resource paths:
+
+```text
+PUT    /api/v1/players/{playerId}/photo
+GET    /api/v1/players/{playerId}/photo
+DELETE /api/v1/players/{playerId}/photo
+```
+
+and the equivalent team paths. Use `@RequestPart("file")`. Replacing or deleting a photo
+must clean up the old storage object. Restore controller coverage for upload/get/delete;
+the focused PR #75 tests intentionally concentrate on the revised membership contract.
+
+### 6. Statistics API review
+
+New issue: #79 — <https://github.com/UltiStatsDev/ultistats-backend/issues/79>
+
+`StatisticsController` currently returns internal `MatchStatistics` models. Before implementing
+DTOs, identify actual frontend views and decide whether one large response remains useful.
+Coordinate with:
+
+- #59 — remove unused/duplicate statistic fields;
+- #35 — CSV export;
+- #71 — offline-first event synchronization and possible cache/version metadata.
+
+Add JSON contract tests so internal aggregator refactors cannot silently change the API.
+
+## Other existing work that affects the API
+
+- #65: transaction boundaries for multi-write use cases. Membership cleanup, team deletion,
+  and future create-team-with-roster commands must be atomic.
+- #71: offline-first batch event processing. It may supersede parts of the single-event append
+  chronology contract, so avoid overfitting single-event endpoints before its design is settled.
+- #23: unknown-player event workflow. Category-specific event patching is the likely correction
+  mechanism, but unknown identity/lifecycle still needs an explicit design.
+
+## Lower-priority cleanup
+
+These can be folded into the issues above or handled in a small API consistency PR:
+
+- fix stale Player sort documentation (`number` and `teamId` are no longer sortable);
+- use explicit path-variable names consistently (`matchId`, `teamId`, `playerId`);
+- add `Location` headers for successful resource creation;
+- remove redundant `@ResponseStatus` when returning `ResponseEntity`;
+- define deterministic membership/roster ordering;
+- remove unused imports and improve OpenAPI response/error annotations;
+- decide whether detail responses should embed memberships while dedicated membership endpoints
+  also exist. The current duplication is acceptable for frontend convenience but should be deliberate.
+
+## Verification expectations for future sessions
+
+For each API change:
+
+1. Add controller contract tests for success and every documented error status.
+2. Add service/integration tests for state transitions and transaction rollback where relevant.
+3. Run `./gradlew test`.
+4. Run `git diff --check`.
+5. Inspect generated OpenAPI/Swagger schemas when polymorphism, multipart, nullable fields, or
+   error responses are involved.

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/EventController.kt
@@ -21,11 +21,21 @@ class EventController(
 ) {
     @GetMapping
     @Operation(summary = "Получить все события матча")
-    fun getAll(@PathVariable matchId: UUID): ResponseEntity<List<Event>> =
+    fun getAll(@PathVariable matchId: UUID): ResponseEntity<List<EventResponse>> =
         when (val result = eventFacade.getAll(matchId)) {
             is EventResult.EventList -> ResponseEntity.ok(result.events)
             else -> ResponseEntity.notFound().build()
         }
+
+    @GetMapping("/{eventId}")
+    @Operation(summary = "Получить событие по ID")
+    fun get(
+        @PathVariable matchId: UUID,
+        @PathVariable eventId: UUID,
+    ): ResponseEntity<EventResponse> = when (val result = eventFacade.get(matchId, eventId)) {
+        is EventResult.Success -> ResponseEntity.ok(result.response)
+        else -> ResponseEntity.notFound().build()
+    }
 
     @PostMapping
     @Operation(summary = "Создать событие")
@@ -40,28 +50,29 @@ class EventController(
             else -> ResponseEntity.internalServerError().build()
         }
 
-    @PutMapping("/{index}")
-    @Operation(summary = "Изменить событие по индексу (частичное обновление)")
+    @PatchMapping("/{eventId}")
+    @Operation(summary = "Исправить участников события")
     fun update(
         @PathVariable matchId: UUID,
-        @PathVariable index: Int,
+        @PathVariable eventId: UUID,
         @RequestBody request: UpdateEventRequest
     ): ResponseEntity<EventResponse> =
-        when (val result = eventFacade.edit(matchId, index, request)) {
+        when (val result = eventFacade.edit(matchId, eventId, request)) {
             is EventResult.Success -> ResponseEntity.ok(result.response)
             is EventResult.NotFound -> ResponseEntity.notFound().build()
             is EventResult.BadRequest -> ResponseEntity.badRequest().build()
+            is EventResult.MethodNotAllowed -> ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build()
             else -> ResponseEntity.internalServerError().build()
         }
 
-    @DeleteMapping("/{index}")
-    @Operation(summary = "Удалить событие по индексу")
+    @DeleteMapping("/{eventId}")
+    @Operation(summary = "Удалить событие по ID")
     fun delete(
         @PathVariable matchId: UUID,
-        @PathVariable index: Int
-    ): ResponseEntity<EventResponse> =
-        when (val result = eventFacade.delete(matchId, index)) {
-            is EventResult.Success -> ResponseEntity.ok(result.response)
+        @PathVariable eventId: UUID
+    ): ResponseEntity<Unit> =
+        when (eventFacade.delete(matchId, eventId)) {
+            is EventResult.Deleted -> ResponseEntity.noContent().build()
             is EventResult.NotFound -> ResponseEntity.notFound().build()
             else -> ResponseEntity.internalServerError().build()
         }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/PlayerController.kt
@@ -8,6 +8,7 @@ import com.github.mihanizzm.ultistats.dto.request.UpdatePlayerRequest
 import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
 import com.github.mihanizzm.ultistats.dto.response.PlayerDetailResponse
 import com.github.mihanizzm.ultistats.dto.response.PlayerListItemResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamPlayerResponse
 import com.github.mihanizzm.ultistats.facade.PlayerFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -62,6 +63,12 @@ class PlayerController(
     fun getById(@PathVariable id: UUID): ResponseEntity<PlayerDetailResponse> =
         playerFacade.getById(id)
             ?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
+
+    @GetMapping("/{playerId}/teams")
+    @Operation(summary = "Получить членства игрока в командах")
+    fun getTeams(@PathVariable playerId: UUID): ResponseEntity<List<TeamPlayerResponse>> =
+        playerFacade.getMemberships(playerId)?.let { ResponseEntity.ok(it) }
             ?: ResponseEntity.notFound().build()
 
     @PostMapping

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/TeamController.kt
@@ -5,9 +5,11 @@ import com.github.mihanizzm.ultistats.dto.common.SortParam
 import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
 import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdateTeamRequest
+import com.github.mihanizzm.ultistats.dto.request.UpsertTeamPlayerRequest
 import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
 import com.github.mihanizzm.ultistats.dto.response.TeamDetailResponse
 import com.github.mihanizzm.ultistats.dto.response.TeamListItemResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamPlayerResponse
 import com.github.mihanizzm.ultistats.facade.TeamFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
@@ -78,26 +81,36 @@ class TeamController(
         if (teamFacade.delete(id)) ResponseEntity.noContent().build()
         else ResponseEntity.notFound().build()
 
-    @PostMapping("/{teamId}/players/{playerId}")
-    @Operation(summary = "Добавить существующего игрока в команду")
-    fun addPlayer(
+    @GetMapping("/{teamId}/players")
+    @Operation(summary = "Получить состав команды")
+    fun getPlayers(@PathVariable teamId: UUID): ResponseEntity<List<TeamPlayerResponse>> =
+        teamFacade.getMemberships(teamId)?.let { ResponseEntity.ok(it) }
+            ?: ResponseEntity.notFound().build()
+
+    @PutMapping("/{teamId}/players/{playerId}")
+    @Operation(summary = "Создать или обновить членство игрока в команде")
+    fun putPlayer(
         @PathVariable teamId: UUID,
         @PathVariable playerId: UUID,
-        @RequestParam(required = false) number: Int?,
-    ): ResponseEntity<TeamDetailResponse> =
-        teamFacade.addPlayerToTeam(teamId, playerId, number)
-            ?.let { ResponseEntity.status(HttpStatus.CREATED).body(it) }
+        @RequestBody request: UpsertTeamPlayerRequest,
+    ): ResponseEntity<TeamPlayerResponse> = try {
+        teamFacade.putPlayer(teamId, playerId, request.number)
+            ?.let { ResponseEntity.ok(it) }
             ?: ResponseEntity.notFound().build()
+    } catch (_: DataIntegrityViolationException) {
+        ResponseEntity.status(HttpStatus.CONFLICT).build()
+    } catch (_: IllegalArgumentException) {
+        ResponseEntity.badRequest().build()
+    }
 
     @DeleteMapping("/{teamId}/players/{playerId}")
     @Operation(summary = "Убрать игрока из команды")
     fun removePlayer(
         @PathVariable teamId: UUID,
         @PathVariable playerId: UUID
-    ): ResponseEntity<TeamDetailResponse> =
-        teamFacade.removePlayerFromTeam(teamId, playerId)
-            ?.let { ResponseEntity.ok(it) }
-            ?: ResponseEntity.notFound().build()
+    ): ResponseEntity<Unit> =
+        if (teamFacade.removePlayer(teamId, playerId)) ResponseEntity.noContent().build()
+        else ResponseEntity.notFound().build()
 
     @PostMapping("/{teamId}/uploadPhoto", consumes =
     [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateEventRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateEventRequest.kt
@@ -1,13 +1,55 @@
 package com.github.mihanizzm.ultistats.dto.request
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.github.mihanizzm.ultistats.model.events.EventType
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
 
-data class CreateEventRequest(
-    val type: EventType,
-    val timestamp: Instant,
-    val teamId: UUID? = null,
-    val playerId: UUID? = null,
-    val toPlayerId: UUID? = null,
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonSubTypes(
+    JsonSubTypes.Type(OnePlayerEventRequest::class, name = "DROP"),
+    JsonSubTypes.Type(OnePlayerEventRequest::class, name = "PULL"),
+    JsonSubTypes.Type(OnePlayerEventRequest::class, name = "BRICK"),
+    JsonSubTypes.Type(OnePlayerEventRequest::class, name = "TURNOVER"),
+    JsonSubTypes.Type(TwoPlayerEventRequest::class, name = "PASS"),
+    JsonSubTypes.Type(TwoPlayerEventRequest::class, name = "GOAL"),
+    JsonSubTypes.Type(TwoPlayerEventRequest::class, name = "BLOCK_MARKER"),
+    JsonSubTypes.Type(TwoPlayerEventRequest::class, name = "BLOCK_FIELD"),
+    JsonSubTypes.Type(TwoPlayerEventRequest::class, name = "INTERCEPTION"),
+    JsonSubTypes.Type(TwoPlayerEventRequest::class, name = "CALLAHAN"),
+    JsonSubTypes.Type(TeamEventRequest::class, name = "TIMEOUT_START"),
+    JsonSubTypes.Type(TeamEventRequest::class, name = "TIMEOUT_END"),
+    JsonSubTypes.Type(SystemEventRequest::class, name = "HALFTIME_START"),
+    JsonSubTypes.Type(SystemEventRequest::class, name = "HALFTIME_END"),
 )
+@Schema(oneOf = [OnePlayerEventRequest::class, TwoPlayerEventRequest::class, TeamEventRequest::class, SystemEventRequest::class])
+sealed interface CreateEventRequest {
+    val type: EventType
+    val occurredAt: Instant
+}
+
+data class OnePlayerEventRequest(
+    override val type: EventType,
+    override val occurredAt: Instant,
+    val playerId: UUID,
+) : CreateEventRequest
+
+data class TwoPlayerEventRequest(
+    override val type: EventType,
+    override val occurredAt: Instant,
+    val fromPlayerId: UUID,
+    val toPlayerId: UUID,
+) : CreateEventRequest
+
+data class TeamEventRequest(
+    override val type: EventType,
+    override val occurredAt: Instant,
+    val teamId: UUID,
+) : CreateEventRequest
+
+data class SystemEventRequest(
+    override val type: EventType,
+    override val occurredAt: Instant,
+) : CreateEventRequest

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreatePlayerRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreatePlayerRequest.kt
@@ -1,10 +1,6 @@
 package com.github.mihanizzm.ultistats.dto.request
 
-import java.util.UUID
-
 data class CreatePlayerRequest(
-    val number: Int?,
     val firstName: String,
     val lastName: String,
-    val teamId: UUID? = null,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateTeamRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/CreateTeamRequest.kt
@@ -1,9 +1,6 @@
 package com.github.mihanizzm.ultistats.dto.request
 
-import java.util.UUID
-
 data class CreateTeamRequest(
     val name: String,
-    val playerIds: List<UUID> = emptyList(),
     val city: String? = null,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpdateEventRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpdateEventRequest.kt
@@ -1,17 +1,36 @@
 package com.github.mihanizzm.ultistats.dto.request
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.github.mihanizzm.ultistats.model.events.EventType
-import java.time.Instant
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.UUID
 
-/**
- * DTO для частичного обновления события.
- * Все поля необязательны — обновляются только переданные поля.
- */
-data class UpdateEventRequest(
-    val type: EventType? = null,
-    val timestamp: Instant? = null,
-    val teamId: UUID? = null,
-    val playerId: UUID? = null,
-    val toPlayerId: UUID? = null,
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonSubTypes(
+    JsonSubTypes.Type(OnePlayerEventPatchRequest::class, name = "DROP"),
+    JsonSubTypes.Type(OnePlayerEventPatchRequest::class, name = "PULL"),
+    JsonSubTypes.Type(OnePlayerEventPatchRequest::class, name = "BRICK"),
+    JsonSubTypes.Type(OnePlayerEventPatchRequest::class, name = "TURNOVER"),
+    JsonSubTypes.Type(TwoPlayerEventPatchRequest::class, name = "PASS"),
+    JsonSubTypes.Type(TwoPlayerEventPatchRequest::class, name = "GOAL"),
+    JsonSubTypes.Type(TwoPlayerEventPatchRequest::class, name = "BLOCK_MARKER"),
+    JsonSubTypes.Type(TwoPlayerEventPatchRequest::class, name = "BLOCK_FIELD"),
+    JsonSubTypes.Type(TwoPlayerEventPatchRequest::class, name = "INTERCEPTION"),
+    JsonSubTypes.Type(TwoPlayerEventPatchRequest::class, name = "CALLAHAN"),
+    JsonSubTypes.Type(TeamEventPatchRequest::class, name = "TIMEOUT_START"),
+    JsonSubTypes.Type(TeamEventPatchRequest::class, name = "TIMEOUT_END"),
+    JsonSubTypes.Type(SystemEventPatchRequest::class, name = "HALFTIME_START"),
+    JsonSubTypes.Type(SystemEventPatchRequest::class, name = "HALFTIME_END"),
 )
+@Schema(oneOf = [OnePlayerEventPatchRequest::class, TwoPlayerEventPatchRequest::class, TeamEventPatchRequest::class])
+sealed interface UpdateEventRequest { val type: EventType }
+
+data class OnePlayerEventPatchRequest(override val type: EventType, val playerId: UUID) : UpdateEventRequest
+data class TwoPlayerEventPatchRequest(
+    override val type: EventType,
+    val fromPlayerId: UUID? = null,
+    val toPlayerId: UUID? = null,
+) : UpdateEventRequest
+data class TeamEventPatchRequest(override val type: EventType, val teamId: UUID) : UpdateEventRequest
+data class SystemEventPatchRequest(override val type: EventType) : UpdateEventRequest

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpdatePlayerRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpdatePlayerRequest.kt
@@ -1,14 +1,10 @@
 package com.github.mihanizzm.ultistats.dto.request
 
-import java.util.UUID
-
 /**
  * DTO для частичного обновления игрока.
  * Все поля необязательны — обновляются только переданные поля.
  */
 data class UpdatePlayerRequest(
-    val number: Int? = null,
     val firstName: String? = null,
     val lastName: String? = null,
-    val teamId: UUID? = null,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpdateTeamRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpdateTeamRequest.kt
@@ -1,13 +1,10 @@
 package com.github.mihanizzm.ultistats.dto.request
 
-import java.util.UUID
-
 /**
  * DTO для частичного обновления команды.
  * Все поля необязательны — обновляются только переданные поля.
  */
 data class UpdateTeamRequest(
     val name: String? = null,
-    val playerIds: List<UUID>? = null,
     val city: String? = null,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpsertTeamPlayerRequest.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/request/UpsertTeamPlayerRequest.kt
@@ -1,0 +1,5 @@
+package com.github.mihanizzm.ultistats.dto.request
+
+data class UpsertTeamPlayerRequest(
+    val number: Int? = null,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/EventResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/EventResponse.kt
@@ -1,7 +1,62 @@
 package com.github.mihanizzm.ultistats.dto.response
 
+import com.github.mihanizzm.ultistats.model.events.EventType
+import com.github.mihanizzm.ultistats.model.events.OnePlayerEvent
+import com.github.mihanizzm.ultistats.model.events.StoredEvent
+import com.github.mihanizzm.ultistats.model.events.SystemEvent
+import com.github.mihanizzm.ultistats.model.events.TeamEvent
+import com.github.mihanizzm.ultistats.model.events.TwoPlayerEvent
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
 import java.util.UUID
 
-data class EventResponse(
-    val eventId: UUID,
-)
+@Schema(oneOf = [OnePlayerEventResponse::class, TwoPlayerEventResponse::class, TeamEventResponse::class, SystemEventResponse::class])
+sealed interface EventResponse {
+    val id: UUID
+    val sequenceNumber: Int
+    val type: EventType
+    val occurredAt: Instant
+
+    companion object {
+        fun from(stored: StoredEvent): EventResponse = when (val event = stored.event) {
+            is OnePlayerEvent -> OnePlayerEventResponse(stored.id, stored.sequenceNumber, event.type, event.occurredAt, event.player)
+            is TwoPlayerEvent -> TwoPlayerEventResponse(
+                stored.id, stored.sequenceNumber, event.type, event.occurredAt, event.fromPlayer, event.toPlayer,
+            )
+            is TeamEvent -> TeamEventResponse(stored.id, stored.sequenceNumber, event.type, event.occurredAt, event.team)
+            is SystemEvent -> SystemEventResponse(stored.id, stored.sequenceNumber, event.type, event.occurredAt)
+        }
+    }
+}
+
+data class OnePlayerEventResponse(
+    override val id: UUID,
+    override val sequenceNumber: Int,
+    override val type: EventType,
+    override val occurredAt: Instant,
+    val playerId: UUID,
+) : EventResponse
+
+data class TwoPlayerEventResponse(
+    override val id: UUID,
+    override val sequenceNumber: Int,
+    override val type: EventType,
+    override val occurredAt: Instant,
+    val fromPlayerId: UUID,
+    val toPlayerId: UUID,
+) : EventResponse
+
+data class TeamEventResponse(
+    override val id: UUID,
+    override val sequenceNumber: Int,
+    override val type: EventType,
+    override val occurredAt: Instant,
+    val teamId: UUID,
+) : EventResponse
+
+data class SystemEventResponse(
+    override val id: UUID,
+    override val sequenceNumber: Int,
+    override val type: EventType,
+    override val occurredAt: Instant,
+) : EventResponse

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/PlayerListItemResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/PlayerListItemResponse.kt
@@ -1,26 +1,20 @@
 package com.github.mihanizzm.ultistats.dto.response
 
 import com.github.mihanizzm.ultistats.model.Player
-import com.github.mihanizzm.ultistats.model.Team
 import java.util.UUID
 
 data class PlayerListItemResponse(
     val id: UUID,
     val firstName: String,
     val lastName: String,
-    val teamName: String?,
-    val number: Int?,
     val photoUrl: String?,
 ) {
     companion object {
-        fun from(player: Player, team: Team?): PlayerListItemResponse =
-            PlayerListItemResponse(
-                id = player.id,
-                firstName = player.firstName,
-                lastName = player.lastName,
-                teamName = team?.name,
-                number = player.number,
-                photoUrl = player.photoUrl,
-            )
+        fun from(player: Player) = PlayerListItemResponse(
+            id = player.id,
+            firstName = player.firstName,
+            lastName = player.lastName,
+            photoUrl = player.photoUrl,
+        )
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamDetailResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamDetailResponse.kt
@@ -2,23 +2,25 @@ package com.github.mihanizzm.ultistats.dto.response
 
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.Team
+import com.github.mihanizzm.ultistats.model.TeamPlayer
 import java.util.UUID
 
 data class TeamDetailResponse(
     val id: UUID,
     val name: String,
-    val players: List<PlayerListItemResponse>,
+    val players: List<TeamRosterPlayerResponse>,
     val city: String?,
     val photoUrl: String?,
 ) {
     companion object {
-        fun from(team: Team, players: List<Player>): TeamDetailResponse =
-            TeamDetailResponse(
-                id = team.id,
-                name = team.name,
-                players = players.map { PlayerListItemResponse.from(it, team) },
-                city = team.city,
-                photoUrl = team.photoUrl,
-            )
+        fun from(team: Team, memberships: List<TeamPlayer>, playersById: Map<UUID, Player>) = TeamDetailResponse(
+            id = team.id,
+            name = team.name,
+            players = memberships.mapNotNull { membership ->
+                playersById[membership.playerId]?.let { TeamRosterPlayerResponse.from(membership, it) }
+            },
+            city = team.city,
+            photoUrl = team.photoUrl,
+        )
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamPlayerResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamPlayerResponse.kt
@@ -1,0 +1,18 @@
+package com.github.mihanizzm.ultistats.dto.response
+
+import com.github.mihanizzm.ultistats.model.TeamPlayer
+import java.util.UUID
+
+data class TeamPlayerResponse(
+    val teamId: UUID,
+    val playerId: UUID,
+    val number: Int?,
+) {
+    companion object {
+        fun from(membership: TeamPlayer) = TeamPlayerResponse(
+            teamId = membership.teamId,
+            playerId = membership.playerId,
+            number = membership.number,
+        )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamRosterPlayerResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/TeamRosterPlayerResponse.kt
@@ -4,20 +4,22 @@ import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.TeamPlayer
 import java.util.UUID
 
-data class PlayerDetailResponse(
-    val id: UUID,
+data class TeamRosterPlayerResponse(
+    val teamId: UUID,
+    val playerId: UUID,
+    val number: Int?,
     val firstName: String,
     val lastName: String,
     val photoUrl: String?,
-    val memberships: List<TeamPlayerResponse>,
 ) {
     companion object {
-        fun from(player: Player, memberships: List<TeamPlayer>) = PlayerDetailResponse(
-            id = player.id,
+        fun from(membership: TeamPlayer, player: Player) = TeamRosterPlayerResponse(
+            teamId = membership.teamId,
+            playerId = membership.playerId,
+            number = membership.number,
             firstName = player.firstName,
             lastName = player.lastName,
             photoUrl = player.photoUrl,
-            memberships = memberships.map(TeamPlayerResponse::from),
         )
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/EventFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/EventFacade.kt
@@ -1,10 +1,19 @@
 package com.github.mihanizzm.ultistats.facade
 
 import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.dto.request.OnePlayerEventPatchRequest
+import com.github.mihanizzm.ultistats.dto.request.OnePlayerEventRequest
+import com.github.mihanizzm.ultistats.dto.request.TeamEventPatchRequest
+import com.github.mihanizzm.ultistats.dto.request.TeamEventRequest
+import com.github.mihanizzm.ultistats.dto.request.TwoPlayerEventPatchRequest
+import com.github.mihanizzm.ultistats.dto.request.TwoPlayerEventRequest
 import com.github.mihanizzm.ultistats.dto.request.UpdateEventRequest
 import com.github.mihanizzm.ultistats.dto.response.EventResponse
 import com.github.mihanizzm.ultistats.factory.EventFactory
-import com.github.mihanizzm.ultistats.model.events.Event
+import com.github.mihanizzm.ultistats.model.events.OnePlayerEvent
+import com.github.mihanizzm.ultistats.model.events.SystemEvent
+import com.github.mihanizzm.ultistats.model.events.TeamEvent
+import com.github.mihanizzm.ultistats.model.events.TwoPlayerEvent
 import com.github.mihanizzm.ultistats.service.EventService
 import com.github.mihanizzm.ultistats.service.MatchService
 import org.springframework.stereotype.Component
@@ -12,9 +21,11 @@ import java.util.UUID
 
 sealed class EventResult {
     data class Success(val response: EventResponse) : EventResult()
-    data class EventList(val events: List<Event>) : EventResult()
+    data class EventList(val events: List<EventResponse>) : EventResult()
+    object Deleted : EventResult()
     object NotFound : EventResult()
     object BadRequest : EventResult()
+    object MethodNotAllowed : EventResult()
 }
 
 @Component
@@ -24,78 +35,51 @@ class EventFacade(
     private val eventFactory: EventFactory,
 ) {
     fun getAll(matchId: UUID): EventResult {
-        if (matchService.get(matchId) == null) {
-            return EventResult.NotFound
-        }
-        return EventResult.EventList(eventService.getAllEventsOfMatch(matchId))
+        if (matchService.get(matchId) == null) return EventResult.NotFound
+        return EventResult.EventList(eventService.getAllEventsOfMatch(matchId).map(EventResponse::from))
+    }
+
+    fun get(matchId: UUID, eventId: UUID): EventResult {
+        if (matchService.get(matchId) == null) return EventResult.NotFound
+        return eventService.get(eventId, matchId)?.let { EventResult.Success(EventResponse.from(it)) }
+            ?: EventResult.NotFound
     }
 
     fun create(matchId: UUID, request: CreateEventRequest): EventResult {
-        if (matchService.get(matchId) == null) {
-            return EventResult.NotFound
-        }
-        val event = eventFactory.createFromRequest(request, matchId)
-            ?: return EventResult.BadRequest
-        val eventId = eventService.create(event, matchId)
-        return EventResult.Success(EventResponse(eventId))
-    }
-
-    fun edit(matchId: UUID, index: Int, request: UpdateEventRequest): EventResult {
-        if (matchService.get(matchId) == null) {
-            return EventResult.NotFound
-        }
-        val existingEvent = eventService.getAllEventsOfMatch(matchId).getOrNull(index)
-            ?: return EventResult.NotFound
-
-        val mergedRequest = when (existingEvent) {
-            is com.github.mihanizzm.ultistats.model.events.OnePlayerEvent -> {
-                CreateEventRequest(
-                    type = request.type ?: existingEvent.type,
-                    timestamp = request.timestamp ?: existingEvent.realTimestamp,
-                    playerId = request.playerId ?: existingEvent.player,
-                )
-            }
-            is com.github.mihanizzm.ultistats.model.events.TwoPlayerEvent -> {
-                CreateEventRequest(
-                    type = request.type ?: existingEvent.type,
-                    timestamp = request.timestamp ?: existingEvent.realTimestamp,
-                    playerId = request.playerId ?: existingEvent.fromPlayer,
-                    toPlayerId = request.toPlayerId ?: existingEvent.toPlayer,
-                )
-            }
-            is com.github.mihanizzm.ultistats.model.events.TeamEvent -> {
-                CreateEventRequest(
-                    type = request.type ?: existingEvent.type,
-                    timestamp = request.timestamp ?: existingEvent.realTimestamp,
-                    teamId = request.teamId ?: existingEvent.team,
-                )
-            }
-            is com.github.mihanizzm.ultistats.model.events.SystemEvent -> {
-                CreateEventRequest(
-                    type = request.type ?: existingEvent.type,
-                    timestamp = request.timestamp ?: existingEvent.realTimestamp,
-                )
-            }
-        }
-        val event = eventFactory.createFromRequest(mergedRequest, matchId) ?: return EventResult.BadRequest
-
+        if (matchService.get(matchId) == null) return EventResult.NotFound
+        val event = eventFactory.createFromRequest(request, matchId) ?: return EventResult.BadRequest
         return try {
-            val eventId = eventService.edit(index, event, matchId)
-            EventResult.Success(EventResponse(eventId))
-        } catch (e: IllegalArgumentException) {
-            EventResult.NotFound
+            EventResult.Success(EventResponse.from(eventService.create(event, matchId)))
+        } catch (_: IllegalArgumentException) {
+            EventResult.BadRequest
         }
     }
 
-    fun delete(matchId: UUID, index: Int): EventResult {
-        if (matchService.get(matchId) == null) {
-            return EventResult.NotFound
+    fun edit(matchId: UUID, eventId: UUID, request: UpdateEventRequest): EventResult {
+        if (matchService.get(matchId) == null) return EventResult.NotFound
+        val stored = eventService.get(eventId, matchId) ?: return EventResult.NotFound
+        if (request.type != stored.event.type) return EventResult.BadRequest
+        val merged: CreateEventRequest = when {
+            stored.event is OnePlayerEvent && request is OnePlayerEventPatchRequest ->
+                OnePlayerEventRequest(stored.event.type, stored.event.occurredAt, request.playerId)
+            stored.event is TwoPlayerEvent && request is TwoPlayerEventPatchRequest ->
+                TwoPlayerEventRequest(
+                    stored.event.type,
+                    stored.event.occurredAt,
+                    request.fromPlayerId ?: stored.event.fromPlayer,
+                    request.toPlayerId ?: stored.event.toPlayer,
+                )
+            stored.event is TeamEvent && request is TeamEventPatchRequest ->
+                TeamEventRequest(stored.event.type, stored.event.occurredAt, request.teamId)
+            stored.event is SystemEvent -> return EventResult.MethodNotAllowed
+            else -> return EventResult.BadRequest
         }
-        return try {
-            val eventId = eventService.remove(index, matchId)
-            EventResult.Success(EventResponse(eventId))
-        } catch (e: IllegalArgumentException) {
-            EventResult.NotFound
-        }
+        val event = eventFactory.createFromRequest(merged, matchId) ?: return EventResult.BadRequest
+        return EventResult.Success(EventResponse.from(eventService.update(eventId, event, matchId)))
+    }
+
+    fun delete(matchId: UUID, eventId: UUID): EventResult {
+        if (matchService.get(matchId) == null) return EventResult.NotFound
+        return if (eventService.remove(eventId, matchId)) EventResult.Deleted else EventResult.NotFound
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/PlayerFacade.kt
@@ -8,10 +8,10 @@ import com.github.mihanizzm.ultistats.dto.request.UpdatePlayerRequest
 import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
 import com.github.mihanizzm.ultistats.dto.response.PlayerDetailResponse
 import com.github.mihanizzm.ultistats.dto.response.PlayerListItemResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamPlayerResponse
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.service.LocalFileStorageService
 import com.github.mihanizzm.ultistats.service.PlayerService
-import com.github.mihanizzm.ultistats.service.TeamService
 import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
 import org.springframework.stereotype.Component
@@ -21,110 +21,52 @@ import java.util.UUID
 @Component
 class PlayerFacade(
     private val playerService: PlayerService,
-    private val teamService: TeamService,
     private val teamPlayerService: TeamPlayerService,
     private val localFileStorageService: LocalFileStorageService,
 ) {
     companion object {
         val DEFAULT_SORT = SortParam("lastName")
-
         val SORT_FIELD_EXTRACTORS: Map<String, (Player) -> Comparable<*>?> = mapOf(
             "lastName" to { it.lastName },
             "firstName" to { it.firstName },
-            "number" to { it.number },
-            "teamId" to { it.teamId?.toString() },
         )
     }
 
-    fun getAll(): List<PlayerDetailResponse> =
-        playerService.getAll().map { player ->
-            val team = player.teamId?.let { teamService.get(it) }
-            PlayerDetailResponse.from(player, team)
-        }
-
-    fun getAllPaged(
-        page: Int,
-        size: Int,
-        filter: PlayerFilterRequest,
-        sortParam: SortParam = DEFAULT_SORT,
-    ): PageResponse<PlayerListItemResponse> {
-        val filteredPlayers = playerService.findAllFiltered(filter)
-        val totalElements = filteredPlayers.size.toLong()
-
-        val sortedPlayers = filteredPlayers.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
-
-        val content = sortedPlayers
-            .drop(page * size)
-            .take(size)
-            .map { player ->
-                val team = player.teamId?.let { teamService.get(it) }
-                PlayerListItemResponse.from(player, team)
-            }
-
-        return PageResponse.of(content, totalElements, page, size)
+    fun getAllPaged(page: Int, size: Int, filter: PlayerFilterRequest, sortParam: SortParam = DEFAULT_SORT): PageResponse<PlayerListItemResponse> {
+        val players = playerService.findAllFiltered(filter)
+        val content = players.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
+            .drop(page * size).take(size).map(PlayerListItemResponse::from)
+        return PageResponse.of(content, players.size.toLong(), page, size)
     }
 
-    fun getById(id: UUID): PlayerDetailResponse? {
-        val player = playerService.get(id) ?: return null
-        val team = player.teamId?.let { teamService.get(it) }
-        return PlayerDetailResponse.from(player, team)
+    fun getById(id: UUID): PlayerDetailResponse? = playerService.get(id)?.let {
+        PlayerDetailResponse.from(it, teamPlayerService.getByPlayerId(id))
+    }
+
+    fun getMemberships(id: UUID): List<TeamPlayerResponse>? {
+        if (playerService.get(id) == null) return null
+        return teamPlayerService.getByPlayerId(id).map(TeamPlayerResponse::from)
     }
 
     fun create(request: CreatePlayerRequest): PlayerDetailResponse {
-        val playerId = UUID.randomUUID()
-        val player = Player(
-            id = playerId,
-            teamId = request.teamId,
-            number = request.number,
-            firstName = request.firstName,
-            lastName = request.lastName,
-        )
+        val player = Player(UUID.randomUUID(), request.firstName, request.lastName)
         playerService.create(player)
-
-        request.teamId?.let { teamId ->
-            teamService.get(teamId)?.let { teamPlayerService.add(teamId, playerId, request.number) }
-        }
-
-        val team = request.teamId?.let { teamService.get(it) }
-        return PlayerDetailResponse.from(player, team)
+        return PlayerDetailResponse.from(player, emptyList())
     }
 
     fun update(id: UUID, request: UpdatePlayerRequest): PlayerDetailResponse? {
-        val existingPlayer = playerService.get(id) ?: return null
-        val oldTeamId = existingPlayer.teamId
-        // teamId может быть null в request, что означает "не менять"
-        // но также teamId может быть null у игрока (игрок без команды)
-        val shouldUpdateTeam = request.teamId != null
-        val newTeamId = request.teamId
-
-        val updatedPlayer = existingPlayer.copy(
-            firstName = request.firstName ?: existingPlayer.firstName,
-            lastName = request.lastName ?: existingPlayer.lastName,
+        val existing = playerService.get(id) ?: return null
+        val updated = existing.copy(
+            firstName = request.firstName ?: existing.firstName,
+            lastName = request.lastName ?: existing.lastName,
         )
-        playerService.update(updatedPlayer)
-
-        // Обновляем связи с командами только если teamId был явно передан
-        if (shouldUpdateTeam && oldTeamId != newTeamId) {
-            oldTeamId?.let { oldId ->
-                teamPlayerService.remove(oldId, id)
-            }
-            newTeamId?.let { newId ->
-                teamService.get(newId)?.let { teamPlayerService.add(newId, id, request.number) }
-            }
-        } else if (request.number != null && oldTeamId != null) {
-            teamPlayerService.add(oldTeamId, id, request.number)
-        }
-
-        val persisted = playerService.get(id) ?: updatedPlayer
-        val team = persisted.teamId?.let { teamService.get(it) }
-        return PlayerDetailResponse.from(persisted, team)
+        playerService.update(updated)
+        return PlayerDetailResponse.from(updated, teamPlayerService.getByPlayerId(id))
     }
 
     fun delete(id: UUID): Boolean {
         if (playerService.get(id) == null) return false
-
         teamPlayerService.getByPlayerId(id).forEach { teamPlayerService.remove(it.teamId, id) }
-
         playerService.delete(id)
         return true
     }
@@ -132,22 +74,17 @@ class PlayerFacade(
     fun uploadPhoto(playerId: UUID, file: MultipartFile): PhotoUrlResponse? {
         val player = playerService.get(playerId) ?: return null
         val url = localFileStorageService.upload(file) ?: return null
-
-        val updatedPlayer = player.copy(photoUrl = url)
-        playerService.update(updatedPlayer)
+        playerService.update(player.copy(photoUrl = url))
         return PhotoUrlResponse(url)
     }
 
-    fun getPhotoUrl(playerId: UUID): PhotoUrlResponse? {
-        val url = playerService.get(playerId)?.photoUrl ?: return null
-        return PhotoUrlResponse(url)
-    }
+    fun getPhotoUrl(playerId: UUID): PhotoUrlResponse? =
+        playerService.get(playerId)?.photoUrl?.let(::PhotoUrlResponse)
 
     fun deletePhotoUrl(playerId: UUID): PhotoUrlResponse? {
         val player = playerService.get(playerId) ?: return null
-        val url = player.photoUrl ?: return PhotoUrlResponse(null)
-        val updatedPlayer = player.copy(photoUrl = null)
-        playerService.update(updatedPlayer)
-        return PhotoUrlResponse(url)
+        val oldUrl = player.photoUrl
+        playerService.update(player.copy(photoUrl = null))
+        return PhotoUrlResponse(oldUrl)
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/TeamFacade.kt
@@ -8,11 +8,12 @@ import com.github.mihanizzm.ultistats.dto.request.UpdateTeamRequest
 import com.github.mihanizzm.ultistats.dto.response.PhotoUrlResponse
 import com.github.mihanizzm.ultistats.dto.response.TeamDetailResponse
 import com.github.mihanizzm.ultistats.dto.response.TeamListItemResponse
+import com.github.mihanizzm.ultistats.dto.response.TeamPlayerResponse
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.LocalFileStorageService
 import com.github.mihanizzm.ultistats.service.PlayerService
-import com.github.mihanizzm.ultistats.service.TeamService
 import com.github.mihanizzm.ultistats.service.TeamPlayerService
+import com.github.mihanizzm.ultistats.service.TeamService
 import com.github.mihanizzm.ultistats.util.SortingUtils.applySorting
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
@@ -27,148 +28,76 @@ class TeamFacade(
 ) {
     companion object {
         val DEFAULT_SORT = SortParam("name")
-
-        val SORT_FIELD_EXTRACTORS: Map<String, (Team) -> Comparable<*>?> = mapOf(
-            "name" to { it.name },
-        )
+        val SORT_FIELD_EXTRACTORS: Map<String, (Team) -> Comparable<*>?> = mapOf("name" to { it.name })
     }
 
-    fun getAll(): List<TeamDetailResponse> =
-        teamService.getAll().map { team ->
-            val players = playerService.getAllByTeamId(team.id)
-            TeamDetailResponse.from(team, players)
-        }
-
-    fun getAllPaged(
-        page: Int,
-        size: Int,
-        filter: TeamFilterRequest,
-        sortParam: SortParam = DEFAULT_SORT,
-    ): PageResponse<TeamListItemResponse> {
-        val filteredTeams = teamService.findAllFiltered(filter)
-        val totalElements = filteredTeams.size.toLong()
-
-        val sortedTeams = filteredTeams.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
-
-        val content = sortedTeams
-            .drop(page * size)
-            .take(size)
-            .map { TeamListItemResponse.from(it) }
-
-        return PageResponse.of(content, totalElements, page, size)
+    private fun detail(team: Team): TeamDetailResponse {
+        val memberships = teamPlayerService.getByTeamId(team.id)
+        val players = playerService.getAllByIds(memberships.map { it.playerId }).associateBy { it.id }
+        return TeamDetailResponse.from(team, memberships, players)
     }
 
-    fun getById(id: UUID): TeamDetailResponse? {
-        val team = teamService.get(id) ?: return null
-        val players = playerService.getAllByTeamId(team.id)
-        return TeamDetailResponse.from(team, players)
+    fun getAllPaged(page: Int, size: Int, filter: TeamFilterRequest, sortParam: SortParam = DEFAULT_SORT): PageResponse<TeamListItemResponse> {
+        val teams = teamService.findAllFiltered(filter)
+        val content = teams.applySorting(sortParam, SORT_FIELD_EXTRACTORS)
+            .drop(page * size).take(size).map(TeamListItemResponse::from)
+        return PageResponse.of(content, teams.size.toLong(), page, size)
+    }
+
+    fun getById(id: UUID): TeamDetailResponse? = teamService.get(id)?.let(::detail)
+
+    fun getMemberships(id: UUID): List<TeamPlayerResponse>? {
+        if (teamService.get(id) == null) return null
+        return teamPlayerService.getByTeamId(id).map(TeamPlayerResponse::from)
     }
 
     fun create(request: CreateTeamRequest): TeamDetailResponse {
-        val teamId = UUID.randomUUID()
-
-        val team = Team(
-            id = teamId,
-            name = request.name,
-            playerIds = request.playerIds,
-            city = request.city,
-        )
+        val team = Team(UUID.randomUUID(), request.name, request.city)
         teamService.create(team)
-
-        request.playerIds.forEach { playerId ->
-            playerService.get(playerId)?.let { teamPlayerService.add(teamId, playerId) }
-        }
-
-        val players = playerService.getAllByTeamId(teamId)
-        return TeamDetailResponse.from(team, players)
+        return detail(team)
     }
 
     fun update(id: UUID, request: UpdateTeamRequest): TeamDetailResponse? {
-        val existingTeam = teamService.get(id) ?: return null
-
-        // Обновляем teamId у игроков, если playerIds был передан
-        val oldPlayerIds = existingTeam.playerIds
-        val newPlayerIds = request.playerIds ?: existingTeam.playerIds
-
-        // Убираем teamId у игроков, которые были удалены из команды
-        (oldPlayerIds - newPlayerIds).forEach { playerId ->
-            teamPlayerService.remove(id, playerId)
-        }
-
-        // Добавляем teamId у новых игроков
-        (newPlayerIds - oldPlayerIds).forEach { playerId ->
-            playerService.get(playerId)?.let { teamPlayerService.add(id, playerId) }
-        }
-
-        val updatedTeam = existingTeam.copy(
-            name = request.name ?: existingTeam.name,
-            playerIds = newPlayerIds,
-            city = request.city ?: existingTeam.city,
+        val existing = teamService.get(id) ?: return null
+        val updated = existing.copy(
+            name = request.name ?: existing.name,
+            city = request.city ?: existing.city,
         )
-        teamService.update(updatedTeam)
-
-        val players = playerService.getAllByTeamId(id)
-        return TeamDetailResponse.from(updatedTeam, players)
+        teamService.update(updated)
+        return detail(updated)
     }
 
     fun delete(id: UUID): Boolean {
-        val team = teamService.get(id) ?: return false
-
-        team.playerIds.forEach { playerId ->
-            teamPlayerService.remove(id, playerId)
-        }
-
+        if (teamService.get(id) == null) return false
+        teamPlayerService.getByTeamId(id).forEach { teamPlayerService.remove(id, it.playerId) }
         teamService.delete(id)
         return true
     }
 
-    fun addPlayerToTeam(teamId: UUID, playerId: UUID, number: Int? = null): TeamDetailResponse? {
-        val team = teamService.get(teamId) ?: return null
-        val player = playerService.get(playerId) ?: return null
-
-        if (team.hasPlayer(playerId)) {
-            if (number != null) teamPlayerService.add(teamId, playerId, number)
-            val players = playerService.getAllByTeamId(teamId)
-            return TeamDetailResponse.from(team, players)
-        }
-
-        teamPlayerService.add(teamId, player.id, number)
-        val updatedTeam = team.copy(playerIds = team.playerIds + playerId)
-
-        val players = playerService.getAllByTeamId(teamId)
-        return TeamDetailResponse.from(updatedTeam, players)
+    fun putPlayer(teamId: UUID, playerId: UUID, number: Int?): TeamPlayerResponse? {
+        require(number == null || number >= 0) { "Player number cannot be negative" }
+        if (teamService.get(teamId) == null || playerService.get(playerId) == null) return null
+        return TeamPlayerResponse.from(teamPlayerService.add(teamId, playerId, number))
     }
 
-    fun removePlayerFromTeam(teamId: UUID, playerId: UUID): TeamDetailResponse? {
-        val team = teamService.get(teamId) ?: return null
-        if (!team.hasPlayer(playerId)) return null
-
-        teamPlayerService.remove(teamId, playerId)
-        val updatedTeam = team.copy(playerIds = team.playerIds - playerId)
-
-        val players = playerService.getAllByTeamId(teamId)
-        return TeamDetailResponse.from(updatedTeam, players)
+    fun removePlayer(teamId: UUID, playerId: UUID): Boolean {
+        if (teamService.get(teamId) == null || playerService.get(playerId) == null) return false
+        return teamPlayerService.remove(teamId, playerId)
     }
 
     fun uploadPhoto(teamId: UUID, file: MultipartFile): PhotoUrlResponse? {
         val team = teamService.get(teamId) ?: return null
         val url = localFileStorageService.upload(file) ?: return null
-
-        val newTeam = team.copy(photoUrl = url)
-        teamService.update(newTeam)
+        teamService.update(team.copy(photoUrl = url))
         return PhotoUrlResponse(url)
     }
 
-    fun getPhotoUrl(teamId: UUID): PhotoUrlResponse? {
-        val url = teamService.get(teamId)?.photoUrl ?: return null
-        return teamService.get(teamId)?.let { PhotoUrlResponse(url) }
-    }
+    fun getPhotoUrl(teamId: UUID): PhotoUrlResponse? = teamService.get(teamId)?.photoUrl?.let(::PhotoUrlResponse)
 
     fun deletePhotoUrl(teamId: UUID): PhotoUrlResponse? {
         val team = teamService.get(teamId) ?: return null
-        val url = team.photoUrl ?: return PhotoUrlResponse(null)
-        val newTeam = team.copy(photoUrl = null)
-        teamService.update(newTeam)
-        return PhotoUrlResponse(url)
+        val oldUrl = team.photoUrl
+        teamService.update(team.copy(photoUrl = null))
+        return PhotoUrlResponse(oldUrl)
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/factory/EventFactory.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/factory/EventFactory.kt
@@ -1,8 +1,13 @@
 package com.github.mihanizzm.ultistats.factory
 
 import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.dto.request.OnePlayerEventRequest
+import com.github.mihanizzm.ultistats.dto.request.SystemEventRequest
+import com.github.mihanizzm.ultistats.dto.request.TeamEventRequest
+import com.github.mihanizzm.ultistats.dto.request.TwoPlayerEventRequest
 import com.github.mihanizzm.ultistats.model.events.Event
 import com.github.mihanizzm.ultistats.model.events.EventCategory
+import com.github.mihanizzm.ultistats.model.events.EventType
 import com.github.mihanizzm.ultistats.model.events.OnePlayerEvent
 import com.github.mihanizzm.ultistats.model.events.SystemEvent
 import com.github.mihanizzm.ultistats.model.events.TeamEvent
@@ -18,43 +23,30 @@ class EventFactory(
     private val matchTeamRepository: SpringDataMatchTeamRepository,
 ) {
     fun createFromRequest(request: CreateEventRequest, matchId: UUID): Event? {
-        val teamByPlayerId = matchPlayerRepository.findAllByMatchId(matchId)
-            .associate { it.playerId to it.teamId }
-        return when (request.type.category) {
-            EventCategory.ONE_PLAYER -> {
-                val playerId = request.playerId ?: return null
-                if (playerId !in teamByPlayerId) return null
-                OnePlayerEvent(
-                    player = playerId,
-                    realTimestamp = request.timestamp,
-                    type = request.type,
-                )
+        val teamByPlayerId = matchPlayerRepository.findAllByMatchId(matchId).associate { it.playerId to it.teamId }
+        return when (request) {
+            is OnePlayerEventRequest -> {
+                if (request.type.category != EventCategory.ONE_PLAYER || request.playerId !in teamByPlayerId) return null
+                OnePlayerEvent(request.playerId, request.occurredAt, request.type)
             }
-            EventCategory.TWO_PLAYER -> {
-                val playerId = request.playerId ?: return null
-                val toPlayerId = request.toPlayerId ?: return null
-                if (playerId !in teamByPlayerId || toPlayerId !in teamByPlayerId) return null
-                TwoPlayerEvent(
-                    fromPlayer = playerId,
-                    toPlayer = toPlayerId,
-                    realTimestamp = request.timestamp,
-                    type = request.type,
-                )
+            is TwoPlayerEventRequest -> {
+                if (request.type.category != EventCategory.TWO_PLAYER) return null
+                val fromTeam = teamByPlayerId[request.fromPlayerId] ?: return null
+                val toTeam = teamByPlayerId[request.toPlayerId] ?: return null
+                val sameTeamRequired = request.type == EventType.PASS || request.type == EventType.GOAL
+                if (sameTeamRequired != (fromTeam == toTeam)) return null
+                TwoPlayerEvent(request.fromPlayerId, request.toPlayerId, request.occurredAt, request.type)
             }
-            EventCategory.TEAM -> {
-                val teamId = request.teamId ?: return null
-                if (matchTeamRepository.findAllByMatchIdOrderByPosition(matchId).none { it.teamId == teamId }) return null
-                TeamEvent(
-                    team = teamId,
-                    realTimestamp = request.timestamp,
-                    type = request.type,
-                )
+            is TeamEventRequest -> {
+                if (request.type.category != EventCategory.TEAM) return null
+                val teamExists = matchTeamRepository.findAllByMatchIdOrderByPosition(matchId)
+                    .any { it.teamId == request.teamId }
+                if (!teamExists) return null
+                TeamEvent(request.teamId, request.occurredAt, request.type)
             }
-            EventCategory.SYSTEM -> {
-                SystemEvent(
-                    realTimestamp = request.timestamp,
-                    type = request.type,
-                )
+            is SystemEventRequest -> {
+                if (request.type.category != EventCategory.SYSTEM) return null
+                SystemEvent(request.occurredAt, request.type)
             }
         }
     }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/EventEntity.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/EventEntity.kt
@@ -22,7 +22,7 @@ import java.util.UUID
  * stays separate so database-only identity, ordering, and soft-deletion fields do not
  * become part of the event API.
  */
-class EventEntity(
+data class EventEntity(
     @Id
     val id: UUID,
 
@@ -72,16 +72,16 @@ class EventEntity(
     companion object {
         fun fromDomain(id: UUID, matchId: UUID, sequenceNumber: Int, event: Event): EventEntity = when (event) {
             is OnePlayerEvent -> EventEntity(
-                id, matchId, sequenceNumber, event.type, event.realTimestamp, fromPlayerId = event.player,
+                id, matchId, sequenceNumber, event.type, event.occurredAt, fromPlayerId = event.player,
             )
             is TwoPlayerEvent -> EventEntity(
-                id, matchId, sequenceNumber, event.type, event.realTimestamp,
+                id, matchId, sequenceNumber, event.type, event.occurredAt,
                 fromPlayerId = event.fromPlayer, toPlayerId = event.toPlayer,
             )
             is TeamEvent -> EventEntity(
-                id, matchId, sequenceNumber, event.type, event.realTimestamp, teamId = event.team,
+                id, matchId, sequenceNumber, event.type, event.occurredAt, teamId = event.team,
             )
-            is SystemEvent -> EventEntity(id, matchId, sequenceNumber, event.type, event.realTimestamp)
+            is SystemEvent -> EventEntity(id, matchId, sequenceNumber, event.type, event.occurredAt)
         }
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
@@ -17,7 +17,7 @@ import java.util.UUID
  * Team, roster, score, and event data live in normalized tables and are populated by
  * MatchServiceImpl when it builds a read model.
  */
-class Match(
+data class Match(
     @Id
     val id: UUID,
 

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchPlayer.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchPlayer.kt
@@ -21,7 +21,7 @@ data class MatchPlayerId(
 @Entity
 @Table(name = "match_players")
 @IdClass(MatchPlayerId::class)
-class MatchPlayer(
+data class MatchPlayer(
     @Id
     @Column(name = "match_id")
     val matchId: UUID,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchTeam.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchTeam.kt
@@ -16,7 +16,7 @@ data class MatchTeamId(
 @Entity
 @Table(name = "match_teams")
 @IdClass(MatchTeamId::class)
-class MatchTeam(
+data class MatchTeam(
     @Id
     @Column(name = "match_id")
     val matchId: UUID,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Player.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Player.kt
@@ -4,21 +4,14 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import jakarta.persistence.Transient
 import java.time.Instant
 import java.util.UUID
 
 @Entity
 @Table(name = "players")
-class Player(
+data class Player(
     @Id
     val id: UUID,
-
-    @Transient
-    val teamId: UUID?,
-
-    @Transient
-    val number: Int?,
 
     @Column(name = "first_name", nullable = false, length = 255)
     val firstName: String,
@@ -33,10 +26,8 @@ class Player(
     val deletedAt: Instant? = null,
 ) {
     companion object {
-        fun unknown(teamId: UUID) = Player(
+        fun unknown() = Player(
             id = UUID.randomUUID(),
-            teamId = teamId,
-            number = null,
             firstName = "N/A",
             lastName = "N/A",
         )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Team.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Team.kt
@@ -4,21 +4,17 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import jakarta.persistence.Transient
 import java.time.Instant
 import java.util.UUID
 
 @Entity
 @Table(name = "teams")
-class Team(
+data class Team(
     @Id
     val id: UUID,
 
     @Column(nullable = false, length = 255)
     val name: String,
-
-    @Transient
-    val playerIds: List<UUID> = emptyList(),
 
     @Column(length = 127)
     val city: String? = null,
@@ -28,6 +24,4 @@ class Team(
 
     @Column(name = "deleted_at")
     val deletedAt: Instant? = null,
-) {
-    fun hasPlayer(playerId: UUID): Boolean = playerIds.contains(playerId)
-}
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/TeamPlayer.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/TeamPlayer.kt
@@ -17,7 +17,7 @@ data class TeamPlayerId(
 @Entity
 @Table(name = "team_players")
 @IdClass(TeamPlayerId::class)
-class TeamPlayer(
+data class TeamPlayer(
     @Id
     @Column(name = "team_id")
     val teamId: UUID,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/Event.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/Event.kt
@@ -12,6 +12,6 @@ import java.time.Instant
     JsonSubTypes.Type(value = SystemEvent::class, name = "SystemEvent"),
 )
 sealed interface Event {
-    val realTimestamp: Instant
+    val occurredAt: Instant
     val type: EventType
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/OnePlayerEvent.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/OnePlayerEvent.kt
@@ -9,7 +9,7 @@ import java.util.UUID
  */
 data class OnePlayerEvent(
     val player: UUID,
-    override val realTimestamp: Instant,
+    override val occurredAt: Instant,
     override val type: EventType,
 ) : Event {
     init {

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/StoredEvent.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/StoredEvent.kt
@@ -1,0 +1,9 @@
+package com.github.mihanizzm.ultistats.model.events
+
+import java.util.UUID
+
+data class StoredEvent(
+    val id: UUID,
+    val sequenceNumber: Int,
+    val event: Event,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/SystemEvent.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/SystemEvent.kt
@@ -7,7 +7,7 @@ import java.time.Instant
  * Используется для: HALFTIME_START, HALFTIME_END.
  */
 data class SystemEvent(
-    override val realTimestamp: Instant,
+    override val occurredAt: Instant,
     override val type: EventType,
 ) : Event {
     init {

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/TeamEvent.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/TeamEvent.kt
@@ -9,7 +9,7 @@ import java.util.UUID
  */
 data class TeamEvent(
     val team: UUID,
-    override val realTimestamp: Instant,
+    override val occurredAt: Instant,
     override val type: EventType,
 ) : Event {
     init {

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/TwoPlayerEvent.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/events/TwoPlayerEvent.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 data class TwoPlayerEvent(
     val fromPlayer: UUID,
     val toPlayer: UUID,
-    override val realTimestamp: Instant,
+    override val occurredAt: Instant,
     override val type: EventType,
 ) : Event {
     init {

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataEventRepository.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/repository/jpa/SpringDataEventRepository.kt
@@ -7,6 +7,8 @@ import java.util.UUID
 interface SpringDataEventRepository : JpaRepository<EventEntity, UUID> {
     fun findAllByMatchIdAndDeletedAtIsNullOrderBySequenceNumber(matchId: UUID): List<EventEntity>
     fun findFirstByMatchIdOrderBySequenceNumberDesc(matchId: UUID): EventEntity?
+    fun findFirstByMatchIdAndDeletedAtIsNullOrderBySequenceNumberDesc(matchId: UUID): EventEntity?
     fun findAllByMatchIdAndDeletedAtIsNull(matchId: UUID): List<EventEntity>
+    fun findByIdAndMatchIdAndDeletedAtIsNull(id: UUID, matchId: UUID): EventEntity?
     fun countByMatchIdAndDeletedAtIsNull(matchId: UUID): Long
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/EventService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/EventService.kt
@@ -1,32 +1,13 @@
 package com.github.mihanizzm.ultistats.service
 
 import com.github.mihanizzm.ultistats.model.events.Event
+import com.github.mihanizzm.ultistats.model.events.StoredEvent
 import java.util.UUID
 
-/**
- * Сервис управления событиями матча.
- */
 interface EventService {
-    /**
-     * Создать новое событие.
-     * @return ID созданного события
-     */
-    fun create(event: Event, matchId: UUID): UUID
-
-    /**
-     * Изменить существующее событие по выбранному индексу.
-     * @return ID изменённого события
-     */
-    fun edit(index: Int, event: Event, matchId: UUID): UUID
-
-    /**
-     * Удалить выбранное событие в матче по индексу.
-     * @return ID удалённого события
-     */
-    fun remove(index: Int, matchId: UUID): UUID
-
-    /**
-     * Получить все события выбранного матча.
-     */
-    fun getAllEventsOfMatch(matchId: UUID): List<Event>
+    fun create(event: Event, matchId: UUID): StoredEvent
+    fun get(eventId: UUID, matchId: UUID): StoredEvent?
+    fun update(eventId: UUID, event: Event, matchId: UUID): StoredEvent
+    fun remove(eventId: UUID, matchId: UUID): Boolean
+    fun getAllEventsOfMatch(matchId: UUID): List<StoredEvent>
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/EventServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/EventServiceImpl.kt
@@ -2,6 +2,7 @@ package com.github.mihanizzm.ultistats.service
 
 import com.github.mihanizzm.ultistats.model.EventEntity
 import com.github.mihanizzm.ultistats.model.events.Event
+import com.github.mihanizzm.ultistats.model.events.StoredEvent
 import com.github.mihanizzm.ultistats.repository.jpa.SpringDataEventRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -14,39 +15,48 @@ class EventServiceImpl(
     private val matchService: MatchService,
 ) : EventService {
     @Transactional
-    override fun create(event: Event, matchId: UUID): UUID {
-        matchService.getOrThrow(matchId)
-        val sequenceNumber = (eventRepository.findFirstByMatchIdOrderBySequenceNumberDesc(matchId)
-            ?.sequenceNumber ?: 0) + 1
-        val entity = EventEntity.fromDomain(UUID.randomUUID(), matchId, sequenceNumber, event)
+    override fun create(event: Event, matchId: UUID): StoredEvent {
+        val match = matchService.getOrThrow(matchId)
+        require(match.startedAt == null || !event.occurredAt.isBefore(match.startedAt)) { "Event precedes match start" }
+        require(match.endedAt == null || !event.occurredAt.isAfter(match.endedAt)) { "Event follows match end" }
+        val lastInSequence = eventRepository.findFirstByMatchIdOrderBySequenceNumberDesc(matchId)
+        val lastActive = eventRepository.findFirstByMatchIdAndDeletedAtIsNullOrderBySequenceNumberDesc(matchId)
+        require(lastActive == null || !event.occurredAt.isBefore(lastActive.occurredAt)) { "Event precedes the previous event" }
+        val entity = EventEntity.fromDomain(UUID.randomUUID(), matchId, (lastInSequence?.sequenceNumber ?: 0) + 1, event)
         eventRepository.save(entity)
         matchService.recalculateScore(matchId)
-        return entity.id
+        return entity.toStored()
+    }
+
+    override fun get(eventId: UUID, matchId: UUID): StoredEvent? {
+        matchService.getOrThrow(matchId)
+        return eventRepository.findByIdAndMatchIdAndDeletedAtIsNull(eventId, matchId)?.toStored()
     }
 
     @Transactional
-    override fun edit(index: Int, event: Event, matchId: UUID): UUID {
-        val existing = getEntities(matchId).getOrNull(index)
-            ?: throw IllegalArgumentException("Event index $index does not exist")
-        eventRepository.save(EventEntity.fromDomain(existing.id, matchId, existing.sequenceNumber, event))
+    override fun update(eventId: UUID, event: Event, matchId: UUID): StoredEvent {
+        val existing = eventRepository.findByIdAndMatchIdAndDeletedAtIsNull(eventId, matchId)
+            ?: throw IllegalArgumentException("Event $eventId does not exist in match $matchId")
+        require(event.type == existing.eventType) { "Event type is immutable" }
+        require(event.occurredAt == existing.occurredAt) { "Event occurrence time is immutable" }
+        val updated = EventEntity.fromDomain(existing.id, matchId, existing.sequenceNumber, event)
+        eventRepository.save(updated)
         matchService.recalculateScore(matchId)
-        return existing.id
+        return updated.toStored()
     }
 
     @Transactional
-    override fun remove(index: Int, matchId: UUID): UUID {
-        val existing = getEntities(matchId).getOrNull(index)
-            ?: throw IllegalArgumentException("Event index $index does not exist")
+    override fun remove(eventId: UUID, matchId: UUID): Boolean {
+        val existing = eventRepository.findByIdAndMatchIdAndDeletedAtIsNull(eventId, matchId) ?: return false
         eventRepository.save(existing.copy(deletedAt = Instant.now()))
         matchService.recalculateScore(matchId)
-        return existing.id
+        return true
     }
 
-    override fun getAllEventsOfMatch(matchId: UUID): List<Event> {
+    override fun getAllEventsOfMatch(matchId: UUID): List<StoredEvent> {
         matchService.getOrThrow(matchId)
-        return getEntities(matchId).map { it.toDomain() }
+        return eventRepository.findAllByMatchIdAndDeletedAtIsNullOrderBySequenceNumber(matchId).map { it.toStored() }
     }
 
-    private fun getEntities(matchId: UUID): List<EventEntity> =
-        eventRepository.findAllByMatchIdAndDeletedAtIsNullOrderBySequenceNumber(matchId)
+    private fun EventEntity.toStored() = StoredEvent(id, sequenceNumber, toDomain())
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/PlayerServiceImpl.kt
@@ -15,12 +15,10 @@ class PlayerServiceImpl(
 ) : PlayerService {
     private val log = LoggerFactory.getLogger(PlayerServiceImpl::class.java)
 
-    override fun get(playerId: UUID): Player? =
-        playerRepository.findByIdAndDeletedAtIsNull(playerId)?.withPrimaryMembership()
+    override fun get(playerId: UUID): Player? = playerRepository.findByIdAndDeletedAtIsNull(playerId)
 
     override fun create(player: Player) {
         playerRepository.save(player)
-        player.teamId?.let { teamPlayerService.add(it, player.id, player.number) }
     }
 
     override fun update(player: Player) {
@@ -31,34 +29,25 @@ class PlayerServiceImpl(
         get(playerId)?.let { playerRepository.save(it.copy(deletedAt = Instant.now())) }
     }
 
-    override fun getAll(): List<Player> = playerRepository.findAllByDeletedAtIsNull().map { it.withPrimaryMembership() }
+    override fun getAll(): List<Player> = playerRepository.findAllByDeletedAtIsNull()
 
     override fun getAllByIds(ids: List<UUID>): List<Player> =
-        playerRepository.findAllByIdInAndDeletedAtIsNull(ids).map { it.withPrimaryMembership() }
+        playerRepository.findAllByIdInAndDeletedAtIsNull(ids)
 
     override fun getAllByTeamId(teamId: UUID): List<Player> {
-        val memberships = teamPlayerService.getByTeamId(teamId).associateBy { it.playerId }
-        return playerRepository.findAllByIdInAndDeletedAtIsNull(memberships.keys.toList()).map { player ->
-            player.copy(teamId = teamId, number = memberships[player.id]?.number)
-        }
+        val playerIds = teamPlayerService.getByTeamId(teamId).map { it.playerId }
+        return playerRepository.findAllByIdInAndDeletedAtIsNull(playerIds)
     }
 
     override fun findAllFiltered(filter: PlayerFilterRequest): List<Player> {
         val players = playerRepository.findFiltered(filter.name)
-        if (filter.teamId == null) return players.map { it.withPrimaryMembership() }
-        val memberships = teamPlayerService.getByTeamId(filter.teamId).associateBy { it.playerId }
-        return players.filter { it.id in memberships }.map {
-            it.copy(teamId = filter.teamId, number = memberships[it.id]?.number)
-        }
+        if (filter.teamId == null) return players
+        val playerIds = teamPlayerService.getByTeamId(filter.teamId).mapTo(mutableSetOf()) { it.playerId }
+        return players.filter { it.id in playerIds }
     }
 
     override fun count(): Long = playerRepository.countByDeletedAtIsNull()
 
     override fun countFiltered(filter: PlayerFilterRequest): Long =
         findAllFiltered(filter).size.toLong()
-
-    private fun Player.withPrimaryMembership(): Player {
-        val membership = teamPlayerService.getByPlayerId(id).firstOrNull() ?: return this
-        return copy(teamId = membership.teamId, number = membership.number)
-    }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/TeamServiceImpl.kt
@@ -2,7 +2,6 @@ package com.github.mihanizzm.ultistats.service
 
 import com.github.mihanizzm.ultistats.dto.request.TeamFilterRequest
 import com.github.mihanizzm.ultistats.model.Team
-import com.github.mihanizzm.ultistats.repository.jpa.SpringDataTeamPlayerRepository
 import com.github.mihanizzm.ultistats.repository.jpa.SpringDataTeamRepository
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -13,11 +12,10 @@ import java.util.UUID
 @Suppress("unused")
 class TeamServiceImpl(
     private val teamRepository: SpringDataTeamRepository,
-    private val teamPlayerRepository: SpringDataTeamPlayerRepository,
 ) : TeamService {
     private val log = LoggerFactory.getLogger(TeamServiceImpl::class.java)
 
-    override fun get(teamId: UUID): Team? = teamRepository.findByIdAndDeletedAtIsNull(teamId)?.withPlayerIds()
+    override fun get(teamId: UUID): Team? = teamRepository.findByIdAndDeletedAtIsNull(teamId)
 
     override fun create(team: Team) {
         teamRepository.save(team)
@@ -31,13 +29,13 @@ class TeamServiceImpl(
         get(teamId)?.let { teamRepository.save(it.copy(deletedAt = Instant.now())) }
     }
 
-    override fun getAll(): List<Team> = teamRepository.findAllByDeletedAtIsNull().withPlayerIds()
+    override fun getAll(): List<Team> = teamRepository.findAllByDeletedAtIsNull()
 
     override fun getAllInList(ids: List<UUID>): List<Team> =
-        teamRepository.findAllByIdInAndDeletedAtIsNull(ids).withPlayerIds()
+        teamRepository.findAllByIdInAndDeletedAtIsNull(ids)
 
     override fun getAllInListIncludingDeleted(ids: List<UUID>): List<Team> =
-        teamRepository.findAllById(ids).toList().withPlayerIds()
+        teamRepository.findAllById(ids).toList()
 
     override fun findAllFiltered(filter: TeamFilterRequest): List<Team> {
         val teams = if (filter.name != null) {
@@ -45,7 +43,7 @@ class TeamServiceImpl(
         } else {
             teamRepository.findAllByDeletedAtIsNull()
         }
-        return teams.withPlayerIds()
+        return teams
     }
 
     override fun count(): Long = teamRepository.countByDeletedAtIsNull()
@@ -56,9 +54,4 @@ class TeamServiceImpl(
         } else {
             teamRepository.countByDeletedAtIsNull()
         }
-
-    private fun List<Team>.withPlayerIds(): List<Team> = map { it.withPlayerIds() }
-
-    private fun Team.withPlayerIds(): Team =
-        copy(playerIds = teamPlayerRepository.findAllByTeamIdAndDeletedAtIsNull(id).map { it.playerId })
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/StatisticsServiceImpl.kt
@@ -5,7 +5,7 @@ import com.github.mihanizzm.ultistats.model.statistics.PlayerStatistics
 import com.github.mihanizzm.ultistats.model.statistics.TeamStatistics
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
-import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -13,16 +13,16 @@ import java.util.UUID
 @Suppress("unused")
 class StatisticsServiceImpl(
     private val matchService: MatchService,
-    private val teamService: TeamService,
     private val playerService: PlayerService,
+    private val teamPlayerService: TeamPlayerService,
     private val statisticsAggregatorList: List<StatisticsAggregator>,
 ) : StatisticsService {
     override fun emptyStatistics(teamIds: List<UUID>): MatchStatistics {
         val teamStats = teamIds
             .map { TeamStatistics(teamId = it) }
 
-        val playersStats = teamService.getAllInList(teamIds)
-            .flatMap { team -> playerService.getAllByIds(team.playerIds) }
+        val playerIds = teamIds.flatMap { teamPlayerService.getByTeamId(it).map { membership -> membership.playerId } }
+        val playersStats = playerService.getAllByIds(playerIds.distinct())
             .map { PlayerStatistics(playerId = it.id) }
 
         return MatchStatistics(

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/TotalTimeStatisticsAggregator.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/TotalTimeStatisticsAggregator.kt
@@ -37,7 +37,7 @@ class TotalTimeStatisticsAggregator : StatisticsAggregator {
         for (event in events) {
             var duration = Duration.ZERO
             if (lastEventTime != null) {
-                duration = Duration.between(lastEventTime, event.realTimestamp)
+                duration = Duration.between(lastEventTime, event.occurredAt)
                 totalMatchTime = totalMatchTime.plus(duration)
 
                 if (currentTeamPossessing != null && !isStopped) {
@@ -48,7 +48,7 @@ class TotalTimeStatisticsAggregator : StatisticsAggregator {
                 }
             }
 
-            lastEventTime = event.realTimestamp
+            lastEventTime = event.occurredAt
 
             when (event.type) {
                 EventType.PASS -> {
@@ -59,14 +59,14 @@ class TotalTimeStatisticsAggregator : StatisticsAggregator {
                     currentTeamPossessing = null
                     isStopped = true
                     // Начинаем отсчет времени между поинтами от момента гола
-                    lastBetweenPointsStart = event.realTimestamp
+                    lastBetweenPointsStart = event.occurredAt
                 }
                 EventType.PULL -> {
                     val pullTeam = teamByPlayerId.getValue((event as OnePlayerEvent).player)
                     // Добавляем во время между поинтами только чистый отрезок между окончанием предыдущего поинта
                     // и текущим пуллом, исключая таймауты и халфтайм.
                     val between = if (lastBetweenPointsStart != null) {
-                        Duration.between(lastBetweenPointsStart, event.realTimestamp)
+                        Duration.between(lastBetweenPointsStart, event.occurredAt)
                     } else {
                         duration
                     }
@@ -97,7 +97,7 @@ class TotalTimeStatisticsAggregator : StatisticsAggregator {
                     currentPlayerPossessing = null
                     isStopped = true
                     // Кэллахан завершает поинт
-                    lastBetweenPointsStart = event.realTimestamp
+                    lastBetweenPointsStart = event.occurredAt
                 }
                 EventType.TIMEOUT_START -> {
                     teamOnTimeout = (event as TeamEvent).team
@@ -111,7 +111,7 @@ class TotalTimeStatisticsAggregator : StatisticsAggregator {
                     }
                     // Между поинтами не должно включать время таймаута, поэтому старт переносим на конец таймаута
                     if (lastBetweenPointsStart != null) {
-                        lastBetweenPointsStart = event.realTimestamp
+                        lastBetweenPointsStart = event.occurredAt
                     }
                 }
                 EventType.HALFTIME_START -> {
@@ -124,7 +124,7 @@ class TotalTimeStatisticsAggregator : StatisticsAggregator {
                     timeSpentOnHalftime = timeSpentOnHalftime.plus(duration)
                     // Между поинтами не должно включать время халфтайма, поэтому старт переносим на конец халфтайма
                     if (lastBetweenPointsStart != null) {
-                        lastBetweenPointsStart = event.realTimestamp
+                        lastBetweenPointsStart = event.occurredAt
                     }
                 }
             }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/MatchAbstractTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/MatchAbstractTest.kt
@@ -10,6 +10,7 @@ import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.statistics.StatisticsService
 import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -32,6 +33,9 @@ abstract class MatchAbstractTest {
 
     @Autowired
     lateinit var playerService: PlayerService
+
+    @Autowired
+    lateinit var teamPlayerService: TeamPlayerService
 
     companion object {
         const val START_DATE = "2025-11-23T12:00:00Z"
@@ -56,36 +60,26 @@ abstract class MatchAbstractTest {
         val PLAYERS_1 = listOf(
             Player(
                 UUIDS[2],
-                UUIDS[0],
-                22,
                 "Михаил",
                 "Сартаков",
             ),
             Player(
                 UUIDS[3],
-                UUIDS[0],
-                71,
                 "Николай",
                 "Вихорев",
             ),
             Player(
                 UUIDS[4],
-                UUIDS[0],
-                11,
                 "Денис",
                 "Братчиков",
             ),
             Player(
                 UUIDS[5],
-                UUIDS[0],
-                73,
                 "Валерия",
                 "Сердюк",
             ),
             Player(
                 UUIDS[6],
-                UUIDS[0],
-                69,
                 "Олег",
                 "Судоплатов",
             ),
@@ -94,36 +88,26 @@ abstract class MatchAbstractTest {
         val PLAYERS_2 = listOf(
             Player(
                 UUIDS[7],
-                UUIDS[1],
-                1,
                 "Алексей",
                 "Иванов",
             ),
             Player(
                 UUIDS[8],
-                UUIDS[1],
-                2,
                 "Иван",
                 "Петров",
             ),
             Player(
                 UUIDS[9],
-                UUIDS[1],
-                5,
                 "Сергей",
                 "Тришкин",
             ),
             Player(
                 UUIDS[10],
-                UUIDS[1],
-                3,
                 "Ксения",
                 "Важева",
             ),
             Player(
                 UUIDS[11],
-                UUIDS[1],
-                4,
                 "Андрей",
                 "Туркин",
             ),
@@ -132,12 +116,10 @@ abstract class MatchAbstractTest {
         val TEAM_1 = Team(
             UUIDS[0],
             "НИИ ТУДА",
-            PLAYERS_1.map { it.id },
         )
         val TEAM_2 = Team(
             UUIDS[1],
             "НИИ СЮДА",
-            PLAYERS_2.map { it.id },
         )
 
         val MATCH = Match(
@@ -158,6 +140,8 @@ abstract class MatchAbstractTest {
 
         PLAYERS_1.forEach { playerService.create(it) }
         PLAYERS_2.forEach { playerService.create(it) }
+        PLAYERS_1.forEachIndexed { index, player -> teamPlayerService.add(TEAM_1.id, player.id, index + 1) }
+        PLAYERS_2.forEachIndexed { index, player -> teamPlayerService.add(TEAM_2.id, player.id, index + 1) }
 
         matchService.create(MATCH)
     }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/RelationalModelIntegrationTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/RelationalModelIntegrationTest.kt
@@ -1,6 +1,6 @@
 package com.github.mihanizzm.ultistats
 
-import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
+import com.github.mihanizzm.ultistats.dto.request.OnePlayerEventRequest
 import com.github.mihanizzm.ultistats.factory.EventFactory
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.Player
@@ -45,15 +45,17 @@ class RelationalModelIntegrationTest {
 
     @BeforeEach
     fun setUp() {
-        firstTeam = Team(UUID.randomUUID(), "First", emptyList())
-        secondTeam = Team(UUID.randomUUID(), "Second", emptyList())
+        firstTeam = Team(UUID.randomUUID(), "First")
+        secondTeam = Team(UUID.randomUUID(), "Second")
         teamService.create(firstTeam)
         teamService.create(secondTeam)
 
-        firstPlayer = Player(UUID.randomUUID(), firstTeam.id, 7, "First", "Player")
-        secondPlayer = Player(UUID.randomUUID(), firstTeam.id, 11, "Second", "Player")
+        firstPlayer = Player(UUID.randomUUID(), "First", "Player")
+        secondPlayer = Player(UUID.randomUUID(), "Second", "Player")
         playerService.create(firstPlayer)
         playerService.create(secondPlayer)
+        teamPlayerService.add(firstTeam.id, firstPlayer.id, 7)
+        teamPlayerService.add(firstTeam.id, secondPlayer.id, 11)
 
         match = Match(UUID.randomUUID(), listOf(firstTeam.id, secondTeam.id))
         matchService.create(match)
@@ -61,7 +63,7 @@ class RelationalModelIntegrationTest {
 
     @Test
     fun `player number is unique inside a team`() {
-        val anotherPlayer = Player(UUID.randomUUID(), null, null, "Another", "Player")
+        val anotherPlayer = Player(UUID.randomUUID(), "Another", "Player")
         playerService.create(anotherPlayer)
 
         assertThrows<DataIntegrityViolationException> {
@@ -97,19 +99,20 @@ class RelationalModelIntegrationTest {
         eventService.create(goal, match.id)
         assertEquals(1, matchService.getOrThrow(match.id).teamScores.single { it.teamId == firstTeam.id }.score)
 
-        eventService.remove(0, match.id)
+        val stored = eventService.getAllEventsOfMatch(match.id).single()
+        eventService.remove(stored.id, match.id)
         assertEquals(0, matchService.getOrThrow(match.id).teamScores.single { it.teamId == firstTeam.id }.score)
     }
 
     @Test
     fun `player added after match creation is rejected by event factory`() {
-        val latePlayer = Player(UUID.randomUUID(), firstTeam.id, 21, "Late", "Player")
+        val latePlayer = Player(UUID.randomUUID(), "Late", "Player")
         playerService.create(latePlayer)
 
         val event = eventFactory.createFromRequest(
-            CreateEventRequest(
+            OnePlayerEventRequest(
                 type = EventType.TURNOVER,
-                timestamp = Instant.parse("2026-07-13T12:00:00Z"),
+                occurredAt = Instant.parse("2026-07-13T12:00:00Z"),
                 playerId = latePlayer.id,
             ),
             match.id,

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
@@ -1,14 +1,12 @@
 package com.github.mihanizzm.ultistats.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.mihanizzm.ultistats.dto.request.CreateEventRequest
-import com.github.mihanizzm.ultistats.dto.request.UpdateEventRequest
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.Team
-import com.github.mihanizzm.ultistats.model.events.EventType
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,280 +15,121 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
-import java.time.Instant
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Suppress("NonAsciiCharacters")
 class EventControllerTest {
-    @Autowired
-    lateinit var mockMvc: MockMvc
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var objectMapper: ObjectMapper
+    @Autowired lateinit var matchService: MatchService
+    @Autowired lateinit var teamService: TeamService
+    @Autowired lateinit var playerService: PlayerService
+    @Autowired lateinit var teamPlayerService: TeamPlayerService
 
-    @Autowired
-    lateinit var objectMapper: ObjectMapper
-
-    @Autowired
-    lateinit var matchService: MatchService
-
-    @Autowired
-    lateinit var teamService: TeamService
-
-    @Autowired
-    lateinit var playerService: PlayerService
-
+    private lateinit var match: Match
     private lateinit var team1: Team
     private lateinit var team2: Team
-    private lateinit var players1: List<Player>
-    private lateinit var players2: List<Player>
-    private lateinit var match: Match
+    private lateinit var player1: Player
+    private lateinit var player2: Player
+    private lateinit var opponent: Player
 
     @BeforeEach
-    fun setup() {
+    fun setUp() {
         matchService.getAll().forEach { matchService.delete(it.id) }
         teamService.getAll().forEach { teamService.delete(it.id) }
         playerService.getAll().forEach { playerService.delete(it.id) }
-
-        val (t1, p1) = createTestTeam("Команда 1")
-        val (t2, p2) = createTestTeam("Команда 2")
-        team1 = t1
-        team2 = t2
-        players1 = p1
-        players2 = p2
-        match = createTestMatch(team1, team2)
-    }
-
-    @Test
-    fun `Создание события TURNOVER возвращает eventId`() {
-        val player = players1.first()
-        val request = CreateEventRequest(
-            type = EventType.TURNOVER,
-            timestamp = Instant.now(),
-            playerId = player.id,
-        )
-
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.eventId").isNotEmpty)
-    }
-
-    @Test
-    fun `Создание события PASS возвращает eventId`() {
-        val player1 = players1[0]
-        val player2 = players1[1]
-
-        // Сначала подбор диска
-        val turnoverRequest = CreateEventRequest(
-            type = EventType.TURNOVER,
-            timestamp = Instant.now(),
-            playerId = player1.id,
-        )
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(turnoverRequest))
-        )
-
-        // Затем пас
-        val passRequest = CreateEventRequest(
-            type = EventType.PASS,
-            timestamp = Instant.now(),
-            playerId = player1.id,
-            toPlayerId = player2.id,
-        )
-
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(passRequest))
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.eventId").isNotEmpty)
-    }
-
-    @Test
-    fun `Создание события GOAL возвращает eventId`() {
-        val player1 = players1[0]
-        val player2 = players1[1]
-
-        // Подбор
-        createEvent(EventType.TURNOVER, player1.id)
-
-        // Гол
-        val goalRequest = CreateEventRequest(
-            type = EventType.GOAL,
-            timestamp = Instant.now(),
-            playerId = player1.id,
-            toPlayerId = player2.id,
-        )
-
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(goalRequest))
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.eventId").isNotEmpty)
-    }
-
-    @Test
-    fun `Получение событий матча возвращает список`() {
-        val fromPlayer = players1[0]
-        val toPlayer = players1[1]
-        createEvent(EventType.TURNOVER, fromPlayer.id)
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(CreateEventRequest(
-                    type = EventType.PASS,
-                    timestamp = Instant.now(),
-                    playerId = fromPlayer.id,
-                    toPlayerId = toPlayer.id,
-                )))
-        ).andExpect(status().isCreated)
-
-        mockMvc.perform(get("/api/v1/matches/${match.id}/events"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.length()").value(2))
-            .andExpect(jsonPath("$[0].player").value(fromPlayer.id.toString()))
-            .andExpect(jsonPath("$[0].team").doesNotExist())
-            .andExpect(jsonPath("$[1].fromPlayer").value(fromPlayer.id.toString()))
-            .andExpect(jsonPath("$[1].toPlayer").value(toPlayer.id.toString()))
-            .andExpect(jsonPath("$[1].fromTeam").doesNotExist())
-            .andExpect(jsonPath("$[1].toTeam").doesNotExist())
-    }
-
-    @Test
-    fun `Удаление события возвращает eventId`() {
-        val player1 = players1[0]
-        val player2 = players1[1]
-
-        // Подбор
-        createEvent(EventType.TURNOVER, player1.id)
-
-        // Пас
-        val passRequest = CreateEventRequest(
-            type = EventType.PASS,
-            timestamp = Instant.now(),
-            playerId = player1.id,
-            toPlayerId = player2.id,
-        )
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(passRequest))
-        )
-
-        // Удаляем пас (индекс 1)
-        mockMvc.perform(delete("/api/v1/matches/${match.id}/events/1"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.eventId").isNotEmpty)
-    }
-
-    @Test
-    fun `Создание события для несуществующего матча возвращает 404`() {
-        val request = CreateEventRequest(
-            type = EventType.PULL,
-            timestamp = Instant.now(),
-            playerId = players1.first().id,
-        )
-
-        mockMvc.perform(
-            post("/api/v1/matches/${UUID.randomUUID()}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Частичное обновление события (PUT только timestamp) работает`() {
-        val player = players1.first()
-
-        // Создаём событие
-        createEvent(EventType.TURNOVER, player.id)
-
-        val newTimestamp = Instant.now().plusSeconds(100)
-        val updateRequest = UpdateEventRequest(timestamp = newTimestamp)
-
-        mockMvc.perform(
-            put("/api/v1/matches/${match.id}/events/0")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-    }
-
-    @Test
-    fun `Частичное обновление события (PUT только type) работает`() {
-        val player = players1.first()
-
-        // Создаём событие TURNOVER
-        createEvent(EventType.TURNOVER, player.id)
-
-        val updateRequest = UpdateEventRequest(type = EventType.DROP)
-
-        mockMvc.perform(
-            put("/api/v1/matches/${match.id}/events/0")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-    }
-
-    @Test
-    fun `Частичное обновление несуществующего события возвращает 404`() {
-        val updateRequest = UpdateEventRequest(timestamp = Instant.now())
-
-        mockMvc.perform(
-            put("/api/v1/matches/${match.id}/events/999")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isNotFound)
-    }
-
-    private fun createEvent(type: EventType, playerId: UUID) {
-        val request = CreateEventRequest(
-            type = type,
-            timestamp = Instant.now(),
-            playerId = playerId,
-        )
-        mockMvc.perform(
-            post("/api/v1/matches/${match.id}/events")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
-    }
-
-    private fun createTestTeam(name: String): Pair<Team, List<Player>> {
-        val teamId = UUID.randomUUID()
-        val players = listOf(
-            Player(UUID.randomUUID(), teamId, 1, "Игрок", "Один"),
-            Player(UUID.randomUUID(), teamId, 2, "Игрок", "Два"),
-        )
-        val team = Team(
-            id = teamId,
-            name = name,
-            playerIds = players.map { it.id }
-        )
-        teamService.create(team)
-        players.forEach { playerService.create(it) }
-        return team to players
-    }
-
-    private fun createTestMatch(team1: Team, team2: Team): Match {
-        val match = Match(
-            id = UUID.randomUUID(),
-            teamIds = listOf(team1.id, team2.id),
-        )
+        team1 = Team(UUID.randomUUID(), "One")
+        team2 = Team(UUID.randomUUID(), "Two")
+        teamService.create(team1); teamService.create(team2)
+        player1 = Player(UUID.randomUUID(), "First", "Player")
+        player2 = Player(UUID.randomUUID(), "Second", "Player")
+        opponent = Player(UUID.randomUUID(), "Other", "Player")
+        listOf(player1, player2, opponent).forEach(playerService::create)
+        teamPlayerService.add(team1.id, player1.id, 1)
+        teamPlayerService.add(team1.id, player2.id, 2)
+        teamPlayerService.add(team2.id, opponent.id, 3)
+        match = Match(UUID.randomUUID(), listOf(team1.id, team2.id))
         matchService.create(match)
-        return match
     }
+
+    @Test
+    fun `one-player event has only its category fields`() {
+        mockMvc.perform(postEvent(mapOf("type" to "TURNOVER", "occurredAt" to "2026-07-14T10:00:00Z", "playerId" to player1.id)))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").isNotEmpty)
+            .andExpect(jsonPath("$.sequenceNumber").value(1))
+            .andExpect(jsonPath("$.playerId").value(player1.id.toString()))
+            .andExpect(jsonPath("$.teamId").doesNotExist())
+            .andExpect(jsonPath("$._eventClass").doesNotExist())
+    }
+
+    @Test
+    fun `two-player request rejects players from wrong team for pass`() {
+        mockMvc.perform(postEvent(mapOf(
+            "type" to "PASS", "occurredAt" to "2026-07-14T10:00:00Z",
+            "fromPlayerId" to player1.id, "toPlayerId" to opponent.id,
+        ))).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `team and system event schemas deserialize by type`() {
+        mockMvc.perform(postEvent(mapOf("type" to "TIMEOUT_START", "occurredAt" to "2026-07-14T10:00:00Z", "teamId" to team1.id)))
+            .andExpect(status().isCreated).andExpect(jsonPath("$.teamId").value(team1.id.toString()))
+        mockMvc.perform(postEvent(mapOf("type" to "HALFTIME_START", "occurredAt" to "2026-07-14T10:01:00Z")))
+            .andExpect(status().isCreated).andExpect(jsonPath("$.teamId").doesNotExist())
+    }
+
+    @Test
+    fun `event is read patched and deleted by UUID`() {
+        val created = mockMvc.perform(postEvent(mapOf("type" to "TURNOVER", "occurredAt" to "2026-07-14T10:00:00Z", "playerId" to player1.id)))
+            .andReturn().response.contentAsString
+        val eventId = objectMapper.readTree(created).get("id").asText()
+
+        mockMvc.perform(get("/api/v1/matches/${match.id}/events/$eventId"))
+            .andExpect(status().isOk).andExpect(jsonPath("$.playerId").value(player1.id.toString()))
+        mockMvc.perform(patch("/api/v1/matches/${match.id}/events/$eventId")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(mapOf("type" to "TURNOVER", "playerId" to player2.id))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.playerId").value(player2.id.toString()))
+            .andExpect(jsonPath("$.occurredAt").value("2026-07-14T10:00:00Z"))
+        mockMvc.perform(delete("/api/v1/matches/${match.id}/events/$eventId"))
+            .andExpect(status().isNoContent)
+        mockMvc.perform(get("/api/v1/matches/${match.id}/events/$eventId")).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `event type cannot change and system event cannot be patched`() {
+        val playerEvent = createAndGetId(mapOf("type" to "TURNOVER", "occurredAt" to "2026-07-14T10:00:00Z", "playerId" to player1.id))
+        mockMvc.perform(patch("/api/v1/matches/${match.id}/events/$playerEvent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(mapOf("type" to "DROP", "playerId" to player1.id))))
+            .andExpect(status().isBadRequest)
+
+        val systemEvent = createAndGetId(mapOf("type" to "HALFTIME_START", "occurredAt" to "2026-07-14T10:01:00Z"))
+        mockMvc.perform(patch("/api/v1/matches/${match.id}/events/$systemEvent")
+            .contentType(MediaType.APPLICATION_JSON).content("""{"type":"HALFTIME_START"}"""))
+            .andExpect(status().isMethodNotAllowed)
+    }
+
+    @Test
+    fun `creation rejects timestamp before previous event`() {
+        createAndGetId(mapOf("type" to "TURNOVER", "occurredAt" to "2026-07-14T10:01:00Z", "playerId" to player1.id))
+        mockMvc.perform(postEvent(mapOf("type" to "DROP", "occurredAt" to "2026-07-14T10:00:00Z", "playerId" to player1.id)))
+            .andExpect(status().isBadRequest)
+    }
+
+    private fun postEvent(body: Map<String, Any>) = post("/api/v1/matches/${match.id}/events")
+        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(body))
+
+    private fun createAndGetId(body: Map<String, Any>): String = objectMapper.readTree(
+        mockMvc.perform(postEvent(body)).andExpect(status().isCreated).andReturn().response.contentAsString
+    ).get("id").asText()
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
@@ -10,6 +10,7 @@ import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -40,6 +41,9 @@ class MatchControllerTest {
 
     @Autowired
     lateinit var playerService: PlayerService
+
+    @Autowired
+    lateinit var teamPlayerService: TeamPlayerService
 
     @BeforeEach
     fun setup() {
@@ -341,16 +345,16 @@ class MatchControllerTest {
     private fun createTestTeam(name: String): Team {
         val teamId = UUID.randomUUID()
         val players = listOf(
-            Player(UUID.randomUUID(), teamId, 1, "Игрок", "Один"),
-            Player(UUID.randomUUID(), teamId, 2, "Игрок", "Два"),
+            Player(UUID.randomUUID(), "Игрок", "Один"),
+            Player(UUID.randomUUID(), "Игрок", "Два"),
         )
         val team = Team(
             id = teamId,
             name = name,
-            playerIds = players.map { it.id }
         )
         teamService.create(team)
         players.forEach { playerService.create(it) }
+        players.forEachIndexed { index, player -> teamPlayerService.add(teamId, player.id, index + 1) }
         return team
     }
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/PlayerControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/PlayerControllerTest.kt
@@ -1,11 +1,10 @@
 package com.github.mihanizzm.ultistats.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.mihanizzm.ultistats.dto.request.CreatePlayerRequest
-import com.github.mihanizzm.ultistats.dto.request.UpdatePlayerRequest
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.PlayerService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,327 +19,65 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Suppress("NonAsciiCharacters")
 class PlayerControllerTest {
-    @Autowired
-    lateinit var mockMvc: MockMvc
-
-    @Autowired
-    lateinit var objectMapper: ObjectMapper
-
-    @Autowired
-    lateinit var playerService: PlayerService
-
-    @Autowired
-    lateinit var teamService: TeamService
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var objectMapper: ObjectMapper
+    @Autowired lateinit var playerService: PlayerService
+    @Autowired lateinit var teamService: TeamService
+    @Autowired lateinit var teamPlayerService: TeamPlayerService
 
     @BeforeEach
-    fun setup() {
+    fun setUp() {
         teamService.getAll().forEach { teamService.delete(it.id) }
         playerService.getAll().forEach { playerService.delete(it.id) }
     }
 
     @Test
-    fun `Получение игроков с пагинацией возвращает PageResponse`() {
-        createTestPlayer("Иван", "Иванов")
-        createTestPlayer("Пётр", "Петров")
-
-        mockMvc.perform(get("/api/v1/players"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(2))
-            .andExpect(jsonPath("$.currentPage").value(0))
+    fun `player CRUD contains no implicit membership fields`() {
+        val created = mockMvc.perform(post("/api/v1/players").contentType(MediaType.APPLICATION_JSON)
+            .content("""{"firstName":"Ivan","lastName":"Ivanov"}"""))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.memberships.length()").value(0))
+            .andExpect(jsonPath("$.team").doesNotExist())
+            .andExpect(jsonPath("$.number").doesNotExist())
+            .andReturn().response.contentAsString
+        val id = objectMapper.readTree(created).get("id").asText()
+        mockMvc.perform(put("/api/v1/players/$id").contentType(MediaType.APPLICATION_JSON)
+            .content("""{"firstName":"Petr"}"""))
+            .andExpect(status().isOk).andExpect(jsonPath("$.firstName").value("Petr"))
+        mockMvc.perform(delete("/api/v1/players/$id")).andExpect(status().isNoContent)
     }
 
     @Test
-    fun `Фильтрация игроков по имени работает`() {
-        createTestPlayer("Иван", "Иванов")
-        createTestPlayer("Пётр", "Иванов")
-        createTestPlayer("Сергей", "Сергеев")
+    fun `player detail and teams endpoint return every explicit membership`() {
+        val player = Player(UUID.randomUUID(), "Multi", "Player")
+        val team1 = Team(UUID.randomUUID(), "One")
+        val team2 = Team(UUID.randomUUID(), "Two")
+        playerService.create(player); teamService.create(team1); teamService.create(team2)
+        teamPlayerService.add(team1.id, player.id, 7)
+        teamPlayerService.add(team2.id, player.id, 17)
 
-        mockMvc.perform(get("/api/v1/players").param("name", "Иванов"))
+        mockMvc.perform(get("/api/v1/players/${player.id}"))
+            .andExpect(status().isOk).andExpect(jsonPath("$.memberships.length()").value(2))
+        mockMvc.perform(get("/api/v1/players/${player.id}/teams"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(2))
+            .andExpect(jsonPath("$[0].playerId").value(player.id.toString()))
+            .andExpect(jsonPath("$[1].playerId").value(player.id.toString()))
     }
 
     @Test
-    fun `Фильтрация игроков по команде работает`() {
-        val team = createTestTeam()
-        createTestPlayer("Иван", "Иванов", team.id)
-        createTestPlayer("Пётр", "Петров", team.id)
-        createTestPlayer("Сергей", "Сергеев", null)
+    fun `player list stays lightweight and can filter by membership`() {
+        val team = Team(UUID.randomUUID(), "One")
+        val included = Player(UUID.randomUUID(), "Included", "Player")
+        val excluded = Player(UUID.randomUUID(), "Excluded", "Player")
+        teamService.create(team); playerService.create(included); playerService.create(excluded)
+        teamPlayerService.add(team.id, included.id, 4)
 
         mockMvc.perform(get("/api/v1/players").param("teamId", team.id.toString()))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(2))
-    }
-
-    @Test
-    fun `Пагинация игроков работает`() {
-        for (i in 1..5) {
-            createTestPlayer("Игрок$i", "Фамилия$i")
-        }
-
-        mockMvc.perform(
-            get("/api/v1/players")
-                .param("page", "0")
-                .param("size", "2")
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(5))
-            .andExpect(jsonPath("$.totalPages").value(3))
-            .andExpect(jsonPath("$.currentPage").value(0))
-
-        mockMvc.perform(
-            get("/api/v1/players")
-                .param("page", "2")
-                .param("size", "2")
-        )
-            .andExpect(status().isOk)
             .andExpect(jsonPath("$.content.length()").value(1))
-            .andExpect(jsonPath("$.currentPage").value(2))
-    }
-
-    @Test
-    fun `Комбинированная фильтрация работает`() {
-        val team = createTestTeam()
-        createTestPlayer("Алексей", "Смирнов", team.id)
-        createTestPlayer("Алексей", "Козлов", null)
-        createTestPlayer("Пётр", "Петров", team.id)
-
-        mockMvc.perform(
-            get("/api/v1/players")
-                .param("name", "Алексей")
-                .param("teamId", team.id.toString())
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(1))
-            .andExpect(jsonPath("$.content[0].firstName").value("Алексей"))
-            .andExpect(jsonPath("$.content[0].lastName").value("Смирнов"))
-    }
-
-    @Test
-    fun `Создание игрока возвращает 201`() {
-        val request = CreatePlayerRequest(
-            number = 10,
-            firstName = "Иван",
-            lastName = "Иванов",
-        )
-
-        mockMvc.perform(
-            post("/api/v1/players")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.firstName").value("Иван"))
-            .andExpect(jsonPath("$.lastName").value("Иванов"))
-            .andExpect(jsonPath("$.id").exists())
-    }
-
-    @Test
-    fun `Получение игрока по ID возвращает 200`() {
-        val player = createTestPlayer("Иван", "Иванов")
-
-        mockMvc.perform(get("/api/v1/players/${player.id}"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.firstName").value("Иван"))
-    }
-
-    @Test
-    fun `Получение несуществующего игрока возвращает 404`() {
-        mockMvc.perform(get("/api/v1/players/${UUID.randomUUID()}"))
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Удаление игрока возвращает 204`() {
-        val player = createTestPlayer("Иван", "Иванов")
-
-        mockMvc.perform(delete("/api/v1/players/${player.id}"))
-            .andExpect(status().isNoContent)
-
-        mockMvc.perform(get("/api/v1/players/${player.id}"))
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Сортировка по умолчанию работает (lastName, firstName)`() {
-        createTestPlayerWithNumber("Борис", "Яковлев", 1)
-        createTestPlayerWithNumber("Анна", "Иванова", 2)
-        createTestPlayerWithNumber("Виктор", "Иванов", 3)
-
-        mockMvc.perform(get("/api/v1/players"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].lastName").value("Иванов"))
-            .andExpect(jsonPath("$.content[0].firstName").value("Виктор"))
-            .andExpect(jsonPath("$.content[1].lastName").value("Иванова"))
-            .andExpect(jsonPath("$.content[2].lastName").value("Яковлев"))
-    }
-
-    @Test
-    fun `Сортировка по номеру работает`() {
-        val team = createTestTeam()
-        createTestPlayerWithNumber("Игрок", "Первый", 10, team.id)
-        createTestPlayerWithNumber("Игрок", "Второй", 5, team.id)
-        createTestPlayerWithNumber("Игрок", "Третий", 15, team.id)
-
-        mockMvc.perform(
-            get("/api/v1/players")
-                .param("sort", "number:asc")
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].number").value(5))
-            .andExpect(jsonPath("$.content[1].number").value(10))
-            .andExpect(jsonPath("$.content[2].number").value(15))
-    }
-
-    @Test
-    fun `Сортировка по убыванию работает`() {
-        createTestPlayerWithNumber("Игрок", "Альфа", 1)
-        createTestPlayerWithNumber("Игрок", "Бета", 2)
-        createTestPlayerWithNumber("Игрок", "Гамма", 3)
-
-        mockMvc.perform(
-            get("/api/v1/players")
-                .param("sort", "lastName:desc")
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].lastName").value("Гамма"))
-            .andExpect(jsonPath("$.content[1].lastName").value("Бета"))
-            .andExpect(jsonPath("$.content[2].lastName").value("Альфа"))
-    }
-
-    @Test
-    fun `Список игроков содержит название команды`() {
-        val team = createTestTeam("Команда Альфа")
-        createTestPlayer("Иван", "Иванов", team.id)
-
-        mockMvc.perform(get("/api/v1/players"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].teamName").value("Команда Альфа"))
-            .andExpect(jsonPath("$.content[0].firstName").value("Иван"))
-            .andExpect(jsonPath("$.content[0].lastName").value("Иванов"))
-    }
-
-    @Test
-    fun `Список игроков содержит null для teamName у игрока без команды`() {
-        createTestPlayer("Иван", "Иванов", null)
-
-        mockMvc.perform(get("/api/v1/players"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].teamName").doesNotExist())
-            .andExpect(jsonPath("$.content[0].firstName").value("Иван"))
-    }
-
-    @Test
-    fun `Список игроков содержит номер игрока`() {
-        val team = createTestTeam()
-        createTestPlayerWithNumber("Иван", "Иванов", 42, team.id)
-
-        mockMvc.perform(get("/api/v1/players"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].number").value(42))
-    }
-
-    @Test
-    fun `Список игроков не содержит teamId`() {
-        val team = createTestTeam("Команда")
-        createTestPlayer("Иван", "Иванов", team.id)
-
-        mockMvc.perform(get("/api/v1/players"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].teamId").doesNotExist())
-    }
-
-    @Test
-    fun `Частичное обновление игрока (только firstName) работает`() {
-        val player = createTestPlayer("Иван", "Иванов")
-
-        val updateRequest = UpdatePlayerRequest(firstName = "Обновлённый")
-
-        mockMvc.perform(
-            put("/api/v1/players/${player.id}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.firstName").value("Обновлённый"))
-            .andExpect(jsonPath("$.lastName").value("Иванов"))
-    }
-
-    @Test
-    fun `Частичное обновление игрока (несколько полей) работает`() {
-        val team = createTestTeam()
-        val player = createTestPlayerWithNumber("Иван", "Иванов", 10, team.id)
-
-        val updateRequest = UpdatePlayerRequest(
-            firstName = "Пётр",
-            number = 99
-        )
-
-        mockMvc.perform(
-            put("/api/v1/players/${player.id}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.firstName").value("Пётр"))
-            .andExpect(jsonPath("$.lastName").value("Иванов"))
-            .andExpect(jsonPath("$.number").value(99))
-    }
-
-    @Test
-    fun `Обновление несуществующего игрока возвращает 404`() {
-        val updateRequest = UpdatePlayerRequest(firstName = "Test")
-
-        mockMvc.perform(
-            put("/api/v1/players/${UUID.randomUUID()}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isNotFound)
-    }
-
-    private fun createTestPlayerWithNumber(
-        firstName: String,
-        lastName: String,
-        number: Int,
-        teamId: UUID? = null,
-    ): Player {
-        val player = Player(
-            id = UUID.randomUUID(),
-            teamId = teamId,
-            number = number,
-            firstName = firstName,
-            lastName = lastName,
-        )
-        playerService.create(player)
-        return player
-    }
-
-    private fun createTestPlayer(firstName: String, lastName: String, teamId: UUID? = null): Player {
-        val player = Player(
-            id = UUID.randomUUID(),
-            teamId = teamId,
-            number = (1..99).random(),
-            firstName = firstName,
-            lastName = lastName,
-        )
-        playerService.create(player)
-        return player
-    }
-
-    private fun createTestTeam(name: String = "Test Team"): Team {
-        val team = Team(
-            id = UUID.randomUUID(),
-            name = name,
-            playerIds = emptyList(),
-        )
-        teamService.create(team)
-        return team
+            .andExpect(jsonPath("$.content[0].id").value(included.id.toString()))
+            .andExpect(jsonPath("$.content[0].memberships").doesNotExist())
+            .andExpect(jsonPath("$.content[0].number").doesNotExist())
     }
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -13,6 +13,7 @@ import com.github.mihanizzm.ultistats.service.EventService
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -47,6 +48,9 @@ class StatisticsControllerTest {
 
     @Autowired
     lateinit var eventService: EventService
+
+    @Autowired
+    lateinit var teamPlayerService: TeamPlayerService
 
     private lateinit var team1: Team
     private lateinit var team2: Team
@@ -142,17 +146,17 @@ class StatisticsControllerTest {
     private fun createTestTeam(name: String): Pair<Team, List<Player>> {
         val teamId = UUID.randomUUID()
         val players = listOf(
-            Player(UUID.randomUUID(), teamId, 1, "Игрок", "Один"),
-            Player(UUID.randomUUID(), teamId, 2, "Игрок", "Два"),
-            Player(UUID.randomUUID(), teamId, 3, "Игрок", "Три"),
+            Player(UUID.randomUUID(), "Игрок", "Один"),
+            Player(UUID.randomUUID(), "Игрок", "Два"),
+            Player(UUID.randomUUID(), "Игрок", "Три"),
         )
         val team = Team(
             id = teamId,
             name = name,
-            playerIds = players.map { it.id }
         )
         teamService.create(team)
         players.forEach { playerService.create(it) }
+        players.forEachIndexed { index, player -> teamPlayerService.add(teamId, player.id, index + 1) }
         return team to players
     }
 

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/TeamControllerTest.kt
@@ -1,317 +1,90 @@
 package com.github.mihanizzm.ultistats.controller
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.mihanizzm.ultistats.dto.request.CreateTeamRequest
-import com.github.mihanizzm.ultistats.dto.request.UpdateTeamRequest
-import com.github.mihanizzm.ultistats.facade.TeamFacade
 import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.service.PlayerService
+import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
-import java.nio.file.Files
-import java.nio.file.Paths
 import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Suppress("NonAsciiCharacters")
 class TeamControllerTest {
-    @Autowired
-    lateinit var mockMvc: MockMvc
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var teamService: TeamService
+    @Autowired lateinit var playerService: PlayerService
+    @Autowired lateinit var teamPlayerService: TeamPlayerService
 
-    @Autowired
-    lateinit var objectMapper: ObjectMapper
-
-    @Autowired
-    lateinit var teamService: TeamService
-
-    @Autowired
-    lateinit var playerService: PlayerService
-
-    @Autowired
-    lateinit var teamFacade: TeamFacade
+    private lateinit var team: Team
+    private lateinit var player: Player
 
     @BeforeEach
-    fun setup() {
+    fun setUp() {
         teamService.getAll().forEach { teamService.delete(it.id) }
         playerService.getAll().forEach { playerService.delete(it.id) }
+        team = Team(UUID.randomUUID(), "Team", "City")
+        player = Player(UUID.randomUUID(), "First", "Player")
+        teamService.create(team); playerService.create(player)
     }
 
     @Test
-    fun `Создание команды возвращает 201`() {
-        val player = Player(
-            id = UUID.randomUUID(),
-            teamId = null,
-            number = 10,
-            firstName = "Иван",
-            lastName = "Иванов",
-        )
-        playerService.create(player)
-
-        val request = CreateTeamRequest(
-            name = "Test Team",
-            playerIds = listOf(player.id),
-        )
-
-        mockMvc.perform(
-            post("/api/v1/teams")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.name").value("Test Team"))
-            .andExpect(jsonPath("$.players[0].firstName").value("Иван"))
-            .andExpect(jsonPath("$.id").exists())
+    fun `team CRUD does not accept roster as entity state`() {
+        mockMvc.perform(post("/api/v1/teams").contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name":"New","city":"Town"}"""))
+            .andExpect(status().isCreated).andExpect(jsonPath("$.players.length()").value(0))
     }
 
     @Test
-    fun `Получение команды по ID возвращает 200`() {
-        val (team, _) = createTestTeam()
-
+    fun `membership put creates and updates stable relationship`() {
+        val url = "/api/v1/teams/${team.id}/players/${player.id}"
+        mockMvc.perform(put(url).contentType(MediaType.APPLICATION_JSON).content("""{"number":7}"""))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.teamId").value(team.id.toString()))
+            .andExpect(jsonPath("$.playerId").value(player.id.toString()))
+            .andExpect(jsonPath("$.number").value(7))
+        mockMvc.perform(put(url).contentType(MediaType.APPLICATION_JSON).content("""{"number":17}"""))
+            .andExpect(status().isOk).andExpect(jsonPath("$.number").value(17))
+        mockMvc.perform(get("/api/v1/teams/${team.id}/players"))
+            .andExpect(status().isOk).andExpect(jsonPath("$.length()").value(1))
         mockMvc.perform(get("/api/v1/teams/${team.id}"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.name").value(team.name))
+            .andExpect(jsonPath("$.players[0].teamId").value(team.id.toString()))
+            .andExpect(jsonPath("$.players[0].number").value(17))
     }
 
     @Test
-    fun `Получение несуществующей команды возвращает 404`() {
-        mockMvc.perform(get("/api/v1/teams/${UUID.randomUUID()}"))
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Получение всех команд с пагинацией возвращает PageResponse`() {
-        createTestTeam("Team 1")
-        createTestTeam("Team 2")
-
-        mockMvc.perform(get("/api/v1/teams"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(2))
-            .andExpect(jsonPath("$.currentPage").value(0))
-    }
-
-    @Test
-    fun `Фильтрация команд по имени работает`() {
-        createTestTeam("Alpha Team")
-        createTestTeam("Beta Team")
-        createTestTeam("Gamma")
-
-        mockMvc.perform(get("/api/v1/teams").param("name", "Team"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(2))
-    }
-
-    @Test
-    fun `Пагинация команд работает`() {
-        for (i in 1..5) {
-            createTestTeam("Team $i")
-        }
-
-        mockMvc.perform(
-            get("/api/v1/teams")
-                .param("page", "0")
-                .param("size", "2")
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(2))
-            .andExpect(jsonPath("$.totalElements").value(5))
-            .andExpect(jsonPath("$.totalPages").value(3))
-            .andExpect(jsonPath("$.currentPage").value(0))
-
-        mockMvc.perform(
-            get("/api/v1/teams")
-                .param("page", "2")
-                .param("size", "2")
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content.length()").value(1))
-            .andExpect(jsonPath("$.currentPage").value(2))
-    }
-
-    @Test
-    fun `Удаление команды возвращает 204`() {
-        val (team, _) = createTestTeam()
-
-        mockMvc.perform(delete("/api/v1/teams/${team.id}"))
+    fun `membership delete returns 204 and removes relationship`() {
+        teamPlayerService.add(team.id, player.id, 8)
+        mockMvc.perform(delete("/api/v1/teams/${team.id}/players/${player.id}"))
             .andExpect(status().isNoContent)
+        mockMvc.perform(get("/api/v1/teams/${team.id}/players"))
+            .andExpect(status().isOk).andExpect(jsonPath("$.length()").value(0))
+    }
 
-        mockMvc.perform(get("/api/v1/teams/${team.id}"))
+    @Test
+    fun `duplicate active number in team returns 409`() {
+        val other = Player(UUID.randomUUID(), "Other", "Player")
+        playerService.create(other)
+        teamPlayerService.add(team.id, player.id, 8)
+        mockMvc.perform(put("/api/v1/teams/${team.id}/players/${other.id}")
+            .contentType(MediaType.APPLICATION_JSON).content("""{"number":8}"""))
+            .andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `membership endpoints return 404 for missing resources`() {
+        mockMvc.perform(put("/api/v1/teams/${team.id}/players/${UUID.randomUUID()}")
+            .contentType(MediaType.APPLICATION_JSON).content("{}"))
             .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Добавление игрока в команду возвращает 201`() {
-        val (team, players) = createTestTeam()
-
-        val newPlayer = Player(
-            id = UUID.randomUUID(),
-            teamId = null,
-            number = 99,
-            firstName = "Новый",
-            lastName = "Игрок",
-        )
-        playerService.create(newPlayer)
-
-        mockMvc.perform(post("/api/v1/teams/${team.id}/players/${newPlayer.id}"))
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.players.length()").value(players.size + 1))
-    }
-
-    @Test
-    fun `Удаление игрока из команды возвращает 200`() {
-        val (team, players) = createTestTeam()
-        val playerId = players.first().id
-
-        mockMvc.perform(delete("/api/v1/teams/${team.id}/players/$playerId"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.players.length()").value(players.size - 1))
-    }
-
-    @Test
-    fun `Сортировка команд по имени работает`() {
-        createTestTeam("Gamma Team")
-        createTestTeam("Alpha Team")
-        createTestTeam("Beta Team")
-
-        mockMvc.perform(get("/api/v1/teams"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].name").value("Alpha Team"))
-            .andExpect(jsonPath("$.content[1].name").value("Beta Team"))
-            .andExpect(jsonPath("$.content[2].name").value("Gamma Team"))
-    }
-
-    @Test
-    fun `Сортировка команд по убыванию работает`() {
-        createTestTeam("Alpha")
-        createTestTeam("Beta")
-        createTestTeam("Gamma")
-
-        mockMvc.perform(
-            get("/api/v1/teams")
-                .param("sort", "name:desc")
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.content[0].name").value("Gamma"))
-            .andExpect(jsonPath("$.content[1].name").value("Beta"))
-            .andExpect(jsonPath("$.content[2].name").value("Alpha"))
-    }
-
-    @Test
-    fun `Частичное обновление команды (только name) работает`() {
-        val (team, _) = createTestTeam("Old Name")
-
-        val updateRequest = UpdateTeamRequest(name = "New Name")
-
-        mockMvc.perform(
-            put("/api/v1/teams/${team.id}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.name").value("New Name"))
-    }
-
-    @Test
-    fun `Частичное обновление команды (только playerIds) работает`() {
-        val (team, oldPlayers) = createTestTeam("Test Team")
-
-        // Создаём нового игрока
-        val newPlayer = Player(
-            id = UUID.randomUUID(),
-            teamId = null,
-            number = 99,
-            firstName = "Новый",
-            lastName = "Игрок",
-        )
-        playerService.create(newPlayer)
-
-        val updateRequest = UpdateTeamRequest(playerIds = listOf(newPlayer.id))
-
-        mockMvc.perform(
-            put("/api/v1/teams/${team.id}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.name").value("Test Team"))
-            .andExpect(jsonPath("$.players.length()").value(1))
-            .andExpect(jsonPath("$.players[0].id").value(newPlayer.id.toString()))
-    }
-
-    @Test
-    fun `Обновление несуществующей команды возвращает 404`() {
-        val updateRequest = UpdateTeamRequest(name = "Test")
-
-        mockMvc.perform(
-            put("/api/v1/teams/${UUID.randomUUID()}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `Создание команды с городом сохраняет город`() {
-        val request = CreateTeamRequest(
-            name = "Team with City",
-            city = "Москва",
-        )
-
-        mockMvc.perform(
-            post("/api/v1/teams")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-        )
-            .andExpect(status().isCreated)
-            .andExpect(jsonPath("$.city").value("Москва"))
-    }
-
-    @Test
-    fun `Обновление команды с городом обновляет город`() {
-        val (team, _) = createTestTeam("Test Team")
-
-        val updateRequest = UpdateTeamRequest(city = "Санкт-Петербург")
-
-        mockMvc.perform(
-            put("/api/v1/teams/${team.id}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(updateRequest))
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.city").value("Санкт-Петербург"))
-    }
-
-    private fun createTestTeam(name: String = "Test Team"): Pair<Team, List<Player>> {
-        val teamId = UUID.randomUUID()
-        val players = listOf(
-            Player(
-                id = UUID.randomUUID(),
-                teamId = teamId,
-                number = 10,
-                firstName = "Тест",
-                lastName = "Игрок",
-            )
-        )
-        val team = Team(
-            id = teamId,
-            name = name,
-            playerIds = players.map { it.id }
-        )
-        teamService.create(team)
-        players.forEach { playerService.create(it) }
-        return team to players
+        mockMvc.perform(get("/api/v1/teams/${UUID.randomUUID()}/players")).andExpect(status().isNotFound)
     }
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/service/EventServiceImplTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/service/EventServiceImplTest.kt
@@ -36,10 +36,10 @@ class EventServiceImplTest : MatchAbstractTest() {
     @Test
     fun `Событие изменяется`() {
         val event = OnePlayerEvent(PLAYERS_1[0].id, now(), EventType.PULL)
-        val newEvent = OnePlayerEvent(PLAYERS_1[1].id, now(), EventType.PULL)
+        val newEvent = OnePlayerEvent(PLAYERS_1[1].id, event.occurredAt, EventType.PULL)
 
-        eventService.create(event, MATCH.id)
-        eventService.edit(0, newEvent, MATCH.id)
+        val stored = eventService.create(event, MATCH.id)
+        eventService.update(stored.id, newEvent, MATCH.id)
 
         val match = matchService.getOrThrow(MATCH.id)
         assertEquals(1, match.events.size)
@@ -50,23 +50,23 @@ class EventServiceImplTest : MatchAbstractTest() {
     fun `Получаем исключение при изменении, если события с таким индексом не существует`() {
         val event = OnePlayerEvent(PLAYERS_1[0].id, now(), EventType.PULL)
 
-        assertThrows<IllegalArgumentException> { eventService.edit(0, event, MATCH.id) }
+        assertThrows<IllegalArgumentException> { eventService.update(java.util.UUID.randomUUID(), event, MATCH.id) }
     }
 
     @Test
     fun `Событие удаляется`() {
         val event = OnePlayerEvent(PLAYERS_1[0].id, now(), EventType.PULL)
 
-        eventService.create(event, MATCH.id)
-        eventService.remove(0, MATCH.id)
+        val stored = eventService.create(event, MATCH.id)
+        eventService.remove(stored.id, MATCH.id)
 
         val match = matchService.getOrThrow(MATCH.id)
         assertEquals(0, match.events.size)
     }
 
     @Test
-    fun `Получаем исключение при удалении, если события с таким индексом не существует`() {
-        assertThrows<IllegalArgumentException> { eventService.remove(0, MATCH.id) }
+    fun `Удаление отсутствующего события возвращает false`() {
+        assertEquals(false, eventService.remove(java.util.UUID.randomUUID(), MATCH.id))
     }
 
     @Test
@@ -81,6 +81,6 @@ class EventServiceImplTest : MatchAbstractTest() {
 
         events.forEach { eventService.create(it, MATCH.id) }
 
-        assertEquals(events, eventService.getAllEventsOfMatch(MATCH.id))
+        assertEquals(events, eventService.getAllEventsOfMatch(MATCH.id).map { it.event })
     }
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/util/SortingIntegrationTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/util/SortingIntegrationTest.kt
@@ -15,9 +15,9 @@ class SortingIntegrationTest {
     @Test
     fun `Сортировка игроков по убыванию фамилии работает`() {
         val players = listOf(
-            Player(UUID.randomUUID(), null, 1, "Игрок", "Альфа"),
-            Player(UUID.randomUUID(), null, 2, "Игрок", "Бета"),
-            Player(UUID.randomUUID(), null, 3, "Игрок", "Гамма"),
+            Player(UUID.randomUUID(), "Игрок", "Альфа"),
+            Player(UUID.randomUUID(), "Игрок", "Бета"),
+            Player(UUID.randomUUID(), "Игрок", "Гамма"),
         )
 
         val sortParam = SortParam("lastName", SortDirection.DESC)


### PR DESCRIPTION
## Summary
- model team rosters as explicit TeamPlayer resources and remove transient membership fields from Player and Team
- add membership read/upsert/delete endpoints in both player and team API flows
- expose category-specific event request/response schemas and address events by stable UUID
- make event type and occurredAt immutable, validate chronology and match participants
- replace obsolete API tests with coverage for memberships, conflicts, polymorphic events, UUID mutation, and chronology

## Breaking API changes
- player create/update no longer accepts teamId or number
- team create/update no longer accepts playerIds
- roster mutation uses PUT/DELETE /api/v1/teams/{teamId}/players/{playerId}
- event mutation uses PATCH/DELETE /api/v1/matches/{matchId}/events/{eventId} instead of list indexes
- event JSON uses occurredAt and category-specific participant fields

## Verification
- ./gradlew test
- git diff --check

Closes #74