### PR TITLE
Удалить неиспользуемые поля статистики

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/MatchTimeStatistics.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/MatchTimeStatistics.kt
@@ -7,6 +7,5 @@ data class MatchTimeStatistics(
     val timeSpentBetweenPoints: Duration = Duration.ZERO,
     val timeSpentOnTimeouts: Duration = Duration.ZERO,
     val timeSpentOnHalftime: Duration = Duration.ZERO,
-    val timeSpentOnViolationDiscussions: Duration = Duration.ZERO,
     val pureGameTime: Duration = Duration.ZERO,
 )

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/PlayerAttackStatistics.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/PlayerAttackStatistics.kt
@@ -5,8 +5,6 @@ data class PlayerAttackStatistics(
     val catches: Int = 0,
     val assists: Int = 0,
     val goals: Int = 0,
-    val saves: Int = 0,
-    val saveGoals: Int = 0,
     val dropsOnMarker: Int = 0,
     val dropsOnField: Int = 0,
     val incompletePasses: Int = 0,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/SystemStatistics.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/SystemStatistics.kt
@@ -1,6 +1,0 @@
-package com.github.mihanizzm.ultistats.model.statistics
-
-data class SystemStatistics(
-    val possessionTime: Double = 0.0,
-    val possessionPercent: Int = 0,
-)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/TeamAttackStatistics.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/statistics/TeamAttackStatistics.kt
@@ -2,12 +2,9 @@ package com.github.mihanizzm.ultistats.model.statistics
 
 data class TeamAttackStatistics(
     val score: Int = 0,
-    val breaks: Int = 0,
     val completePasses: Int = 0,
     val allPasses: Int = 0,
     val pulls: Int = 0,
     val bricks: Int = 0,
     val possessions: Int = 0,
-    val possessionTime: Double = 0.0,
-    val percentOfPossession: Double = 0.0,
 )

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -84,6 +84,29 @@ class StatisticsControllerTest {
     }
 
     @Test
+    fun `Незаполняемые и дублирующиеся поля не публикуются в статистике`() {
+        val response = mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val statistics = objectMapper.readTree(response.response.contentAsString)
+        val removedFields = listOf(
+            "saves",
+            "saveGoals",
+            "breaks",
+            "possessionTime",
+            "percentOfPossession",
+            "timeSpentOnViolationDiscussions",
+        )
+
+        removedFields.forEach { field ->
+            assertThat(statistics.findValues(field))
+                .describedAs("Поле %s не должно входить в Statistics API", field)
+                .isEmpty()
+        }
+    }
+
+    @Test
     fun `Статистика использует контракт участников матча и включает неизвестных`() {
         val participants = matchService.getOrThrow(match.id).participantsByTeam.values.flatten()
         val unknownParticipantIds = participants


### PR DESCRIPTION
## Что изменено

- удалены незаполняемые `saves`, `saveGoals`, `breaks` и `timeSpentOnViolationDiscussions`;
- удалены дублирующиеся числовые поля владения из `TeamAttackStatistics`;
- удалён неиспользуемый `SystemStatistics`;
- добавлен controller contract test, проверяющий отсутствие retired-полей в реальном Statistics API JSON.

## Проверка

- TDD: новый contract test сначала падал на присутствующем `saves: 0`, затем стал зелёным после удаления полей;
- `./gradlew cleanTest test` на Java 21 — 175 тестов, 0 failures/errors/skips;
- обязательный contract self-review — Critical 0, Important 0, Nit 0.

Closes #59
