### PR TITLE
Стабилизировать Statistics API

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
@@ -19,10 +19,8 @@ class StatisticsController(
     @GetMapping
     @Operation(summary = "Получить статистику матча")
     fun getStatistics(@PathVariable matchId: UUID): ResponseEntity<MatchStatistics> {
-        if (matchService.get(matchId) == null) {
-            return ResponseEntity.notFound().build()
-        }
-        val statistics = statisticsService.recalculateMatchStatistics(matchId)
+        val match = matchService.get(matchId) ?: return ResponseEntity.notFound().build()
+        val statistics = statisticsService.recalculateMatchStatistics(match)
         return ResponseEntity.ok(statistics)
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
@@ -1,26 +1,73 @@
 package com.github.mihanizzm.ultistats.controller
 
-import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
-import com.github.mihanizzm.ultistats.service.MatchService
-import com.github.mihanizzm.ultistats.service.statistics.StatisticsService
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.facade.StatisticsFacade
+import com.github.mihanizzm.ultistats.validation.match.MatchProblem
+import com.github.mihanizzm.ultistats.validation.match.MatchProblemCode
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/matches/{matchId}/statistics")
 @Tag(name = "Statistics", description = "Получение статистики матча")
 class StatisticsController(
-    private val statisticsService: StatisticsService,
-    private val matchService: MatchService,
+    private val statisticsFacade: StatisticsFacade,
 ) {
     @GetMapping
     @Operation(summary = "Получить статистику матча")
-    fun getStatistics(@PathVariable matchId: UUID): ResponseEntity<MatchStatistics> {
-        val match = matchService.get(matchId) ?: return ResponseEntity.notFound().build()
-        val statistics = statisticsService.recalculateMatchStatistics(match)
-        return ResponseEntity.ok(statistics)
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Статистика матча",
+                content = [Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = Schema(implementation = MatchStatisticsResponse::class),
+                    examples = [ExampleObject(
+                        value = """{"matchId":"00000000-0000-0000-0000-000000000100","teams":[{"teamId":"00000000-0000-0000-0000-000000000001","teamName":"Flying Bears","attack":{"score":1,"completePasses":1,"allPasses":1,"pulls":1,"bricks":0,"possessions":1},"defense":{"blocks":0,"blocksAsMarker":0,"blocksAsFieldPlayer":0,"interceptions":0,"callahans":0},"time":{"possessionTimeMs":42000,"betweenPointsTimeMs":7000,"timeoutTimeMs":0},"participants":[{"participantId":"00000000-0000-0000-0000-000000000010","kind":"PLAYER","unknownSlot":null,"firstName":"Ivan","lastName":"Ivanov","displayName":"Ivan Ivanov","number":17,"attack":{"passes":1,"catches":1,"assists":1,"goals":0,"dropsOnMarker":0,"dropsOnField":0,"incompletePasses":0,"callahanDrops":0,"discPossessions":1,"pulls":0,"bricks":0},"defense":{"blocks":0,"blocksAsMarker":0,"blocksAsFieldPlayer":0,"interceptions":0,"callahans":0},"time":{"possessionTimeMs":42000,"averagePossessionTimeMs":42000}}]}],"time":{"totalTimeMs":90000,"betweenPointsTimeMs":7000,"timeoutTimeMs":0,"halftimeTimeMs":0,"pureGameTimeMs":83000}}""",
+                    )],
+                )],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Матч не найден",
+                content = [Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = Schema(implementation = ProblemDetail::class),
+                )],
+            ),
+        ],
+    )
+    fun getStatistics(
+        @PathVariable matchId: UUID,
+        request: HttpServletRequest,
+    ): ResponseEntity<*> = statisticsFacade.get(matchId)
+        ?.let { ResponseEntity.ok(it) }
+        ?: notFound(matchId, request)
+
+    private fun notFound(matchId: UUID, request: HttpServletRequest): ResponseEntity<ProblemDetail> {
+        val problem = MatchProblem(
+            code = MatchProblemCode.RESOURCE_NOT_FOUND,
+            title = "Resource not found",
+            detail = "Match $matchId not found",
+        )
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(problem.toProblemDetail(HttpStatus.NOT_FOUND, URI.create(request.requestURI)))
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchListItemResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchListItemResponse.kt
@@ -23,7 +23,7 @@ data class MatchListItemResponse(
                         val teamScore = match.teamScores.find { it.teamId == teamId }?.score ?: 0
                         MatchListTeamResponse(
                             teamId = team.id,
-                            teamName = team.name,
+                            teamName = match.teamNamesById.getValue(teamId),
                             teamScore = teamScore,
                             city = team.city,
                             photoUrl = team.photoUrl,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchParticipantResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchParticipantResponse.kt
@@ -8,6 +8,9 @@ data class MatchParticipantResponse(
     val participantId: UUID,
     val kind: MatchParticipantKind,
     val unknownSlot: Int?,
+    val firstName: String?,
+    val lastName: String?,
+    val displayName: String,
     val number: Int?,
 ) {
     companion object {
@@ -15,6 +18,9 @@ data class MatchParticipantResponse(
             participantId = participant.participantId,
             kind = participant.kind,
             unknownSlot = participant.unknownSlot,
+            firstName = participant.firstName,
+            lastName = participant.lastName,
+            displayName = participant.displayName,
             number = participant.number,
         )
     }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchParticipantResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchParticipantResponse.kt
@@ -1,9 +1,11 @@
 package com.github.mihanizzm.ultistats.dto.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.github.mihanizzm.ultistats.model.MatchParticipant
 import com.github.mihanizzm.ultistats.model.MatchParticipantKind
 import java.util.UUID
 
+@JsonInclude(JsonInclude.Include.ALWAYS)
 data class MatchParticipantResponse(
     val participantId: UUID,
     val kind: MatchParticipantKind,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/MatchResponse.kt
@@ -23,7 +23,7 @@ data class MatchResponse(
                     val teamScore = match.teamScores.find { it.teamId == teamId }?.score ?: 0
                     MatchTeamResponse(
                         teamId = team.id,
-                        teamName = team.name,
+                        teamName = match.teamNamesById.getValue(teamId),
                         teamScore = teamScore,
                         participants = match.participantsByTeam[teamId].orEmpty().map(MatchParticipantResponse::from),
                         city = team.city,

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/DefenseStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/DefenseStatisticsResponse.kt
@@ -1,0 +1,9 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+data class DefenseStatisticsResponse(
+    val blocks: Int,
+    val blocksAsMarker: Int,
+    val blocksAsFieldPlayer: Int,
+    val interceptions: Int,
+    val callahans: Int,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/MatchStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/MatchStatisticsResponse.kt
@@ -1,0 +1,9 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+import java.util.UUID
+
+data class MatchStatisticsResponse(
+    val matchId: UUID,
+    val teams: List<TeamStatisticsResponse>,
+    val time: MatchTimeStatisticsResponse,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/MatchTimeStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/MatchTimeStatisticsResponse.kt
@@ -1,0 +1,9 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+data class MatchTimeStatisticsResponse(
+    val totalTimeMs: Long,
+    val betweenPointsTimeMs: Long,
+    val timeoutTimeMs: Long,
+    val halftimeTimeMs: Long,
+    val pureGameTimeMs: Long,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/ParticipantStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/ParticipantStatisticsResponse.kt
@@ -1,0 +1,19 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.github.mihanizzm.ultistats.model.MatchParticipantKind
+import java.util.UUID
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+data class ParticipantStatisticsResponse(
+    val participantId: UUID,
+    val kind: MatchParticipantKind,
+    val unknownSlot: Int?,
+    val firstName: String?,
+    val lastName: String?,
+    val displayName: String,
+    val number: Int?,
+    val attack: PlayerAttackStatisticsResponse,
+    val defense: DefenseStatisticsResponse,
+    val time: PlayerTimeStatisticsResponse,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/PlayerAttackStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/PlayerAttackStatisticsResponse.kt
@@ -1,0 +1,15 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+data class PlayerAttackStatisticsResponse(
+    val passes: Int,
+    val catches: Int,
+    val assists: Int,
+    val goals: Int,
+    val dropsOnMarker: Int,
+    val dropsOnField: Int,
+    val incompletePasses: Int,
+    val callahanDrops: Int,
+    val discPossessions: Int,
+    val pulls: Int,
+    val bricks: Int,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/PlayerTimeStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/PlayerTimeStatisticsResponse.kt
@@ -1,0 +1,6 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+data class PlayerTimeStatisticsResponse(
+    val possessionTimeMs: Long,
+    val averagePossessionTimeMs: Long,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/TeamAttackStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/TeamAttackStatisticsResponse.kt
@@ -1,0 +1,10 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+data class TeamAttackStatisticsResponse(
+    val score: Int,
+    val completePasses: Int,
+    val allPasses: Int,
+    val pulls: Int,
+    val bricks: Int,
+    val possessions: Int,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/TeamStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/TeamStatisticsResponse.kt
@@ -1,0 +1,12 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+import java.util.UUID
+
+data class TeamStatisticsResponse(
+    val teamId: UUID,
+    val teamName: String,
+    val attack: TeamAttackStatisticsResponse,
+    val defense: DefenseStatisticsResponse,
+    val time: TeamTimeStatisticsResponse,
+    val participants: List<ParticipantStatisticsResponse>,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/TeamTimeStatisticsResponse.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/dto/response/statistics/TeamTimeStatisticsResponse.kt
@@ -1,0 +1,7 @@
+package com.github.mihanizzm.ultistats.dto.response.statistics
+
+data class TeamTimeStatisticsResponse(
+    val possessionTimeMs: Long,
+    val betweenPointsTimeMs: Long,
+    val timeoutTimeMs: Long,
+)

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacade.kt
@@ -1,0 +1,23 @@
+package com.github.mihanizzm.ultistats.facade
+
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.mapper.StatisticsResponseMapper
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.statistics.StatisticsService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class StatisticsFacade(
+    private val matchService: MatchService,
+    private val statisticsService: StatisticsService,
+    private val responseMapper: StatisticsResponseMapper,
+) {
+    fun get(matchId: UUID): MatchStatisticsResponse? {
+        val match = matchService.get(matchId) ?: return null
+        return responseMapper.toResponse(
+            match,
+            statisticsService.recalculateMatchStatistics(match),
+        )
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/mapper/StatisticsResponseMapper.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/mapper/StatisticsResponseMapper.kt
@@ -1,0 +1,119 @@
+package com.github.mihanizzm.ultistats.mapper
+
+import com.github.mihanizzm.ultistats.dto.response.statistics.DefenseStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.ParticipantStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.PlayerAttackStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.PlayerTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamAttackStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.MatchParticipant
+import com.github.mihanizzm.ultistats.model.statistics.DefenseStatistics
+import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
+import com.github.mihanizzm.ultistats.model.statistics.MatchTimeStatistics
+import com.github.mihanizzm.ultistats.model.statistics.PlayerAttackStatistics
+import com.github.mihanizzm.ultistats.model.statistics.PlayerStatistics
+import com.github.mihanizzm.ultistats.model.statistics.PlayerTimeStatistics
+import com.github.mihanizzm.ultistats.model.statistics.TeamAttackStatistics
+import com.github.mihanizzm.ultistats.model.statistics.TeamTimeStatistics
+import org.springframework.stereotype.Component
+
+@Component
+class StatisticsResponseMapper {
+    fun toResponse(match: Match, statistics: MatchStatistics): MatchStatisticsResponse {
+        val teamsById = statistics.teamStatistics.associateBy { it.teamId }
+        val participantsById = statistics.playerStatistics.associateBy { it.participantId }
+
+        return MatchStatisticsResponse(
+            matchId = match.id,
+            teams = match.teamIds.map { teamId ->
+                val team = checkNotNull(teamsById[teamId]) {
+                    "Statistics missing for team $teamId"
+                }
+                TeamStatisticsResponse(
+                    teamId = teamId,
+                    teamName = checkNotNull(match.teamNamesById[teamId]) {
+                        "Display snapshot missing for team $teamId"
+                    },
+                    attack = team.attack.toResponse(),
+                    defense = team.defense.toResponse(),
+                    time = team.time.toResponse(),
+                    participants = match.participantsByTeam[teamId].orEmpty().map { participant ->
+                        participant.toResponse(
+                            checkNotNull(participantsById[participant.participantId]) {
+                                "Statistics missing for participant ${participant.participantId}"
+                            },
+                        )
+                    },
+                )
+            },
+            time = statistics.timeStatistics.toResponse(),
+        )
+    }
+
+    private fun MatchParticipant.toResponse(statistics: PlayerStatistics) = ParticipantStatisticsResponse(
+        participantId = participantId,
+        kind = kind,
+        unknownSlot = unknownSlot,
+        firstName = firstName,
+        lastName = lastName,
+        displayName = displayName,
+        number = number,
+        attack = statistics.attack.toResponse(),
+        defense = statistics.defense.toResponse(),
+        time = statistics.time.toResponse(),
+    )
+
+    private fun TeamAttackStatistics.toResponse() = TeamAttackStatisticsResponse(
+        score = score,
+        completePasses = completePasses,
+        allPasses = allPasses,
+        pulls = pulls,
+        bricks = bricks,
+        possessions = possessions,
+    )
+
+    private fun PlayerAttackStatistics.toResponse() = PlayerAttackStatisticsResponse(
+        passes = passes,
+        catches = catches,
+        assists = assists,
+        goals = goals,
+        dropsOnMarker = dropsOnMarker,
+        dropsOnField = dropsOnField,
+        incompletePasses = incompletePasses,
+        callahanDrops = callahanDrops,
+        discPossessions = discPossessions,
+        pulls = pulls,
+        bricks = bricks,
+    )
+
+    private fun DefenseStatistics.toResponse() = DefenseStatisticsResponse(
+        blocks = blocks,
+        blocksAsMarker = blocksAsMarker,
+        blocksAsFieldPlayer = blocksAsFieldPlayer,
+        interceptions = interceptions,
+        callahans = callahans,
+    )
+
+    private fun MatchTimeStatistics.toResponse() = MatchTimeStatisticsResponse(
+        totalTimeMs = totalTime.toMillis(),
+        betweenPointsTimeMs = timeSpentBetweenPoints.toMillis(),
+        timeoutTimeMs = timeSpentOnTimeouts.toMillis(),
+        halftimeTimeMs = timeSpentOnHalftime.toMillis(),
+        pureGameTimeMs = pureGameTime.toMillis(),
+    )
+
+    private fun TeamTimeStatistics.toResponse() = TeamTimeStatisticsResponse(
+        possessionTimeMs = totalPossessionTime.toMillis(),
+        betweenPointsTimeMs = totalTimeBetweenPoints.toMillis(),
+        timeoutTimeMs = totalTimeSpentOnTimeouts.toMillis(),
+    )
+
+    private fun PlayerTimeStatistics.toResponse() = PlayerTimeStatisticsResponse(
+        possessionTimeMs = totalPossessionTime.toMillis(),
+        averagePossessionTimeMs = averagePossessionTime.toMillis(),
+    )
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/Match.kt
@@ -36,6 +36,9 @@ data class Match(
     @Transient
     val participantsByTeam: Map<UUID, List<MatchParticipant>> = emptyMap(),
 
+    @Transient
+    val teamNamesById: Map<UUID, String> = emptyMap(),
+
     @Column(name = "planned_start_timestamp")
     val plannedStartTimestamp: Instant? = null,
 

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchParticipant.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchParticipant.kt
@@ -42,15 +42,37 @@ data class MatchParticipant(
     @Column(name = "unknown_slot")
     val unknownSlot: Int? = null,
 
+    @Column(name = "first_name", length = 255)
+    val firstName: String? = null,
+
+    @Column(name = "last_name", length = 255)
+    val lastName: String? = null,
+
     @Column
     val number: Int? = null,
 ) {
+    @get:jakarta.persistence.Transient
+    val displayName: String
+        get() = when (kind) {
+            MatchParticipantKind.PLAYER -> "${requireNotNull(firstName)} ${requireNotNull(lastName)}"
+            MatchParticipantKind.UNKNOWN -> "Неизвестный игрок ${requireNotNull(unknownSlot)}"
+        }
+
     companion object {
-        fun player(matchId: UUID, teamId: UUID, playerId: UUID, number: Int?) = MatchParticipant(
+        fun player(
+            matchId: UUID,
+            teamId: UUID,
+            playerId: UUID,
+            firstName: String,
+            lastName: String,
+            number: Int?,
+        ) = MatchParticipant(
             matchId = matchId,
             participantId = playerId,
             teamId = teamId,
             kind = MatchParticipantKind.PLAYER,
+            firstName = firstName,
+            lastName = lastName,
             number = number,
         )
 

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchParticipant.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchParticipant.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.IdClass
 import jakarta.persistence.Table
+import jakarta.persistence.Transient
 import java.io.Serializable
 import java.util.UUID
 
@@ -51,7 +52,7 @@ data class MatchParticipant(
     @Column
     val number: Int? = null,
 ) {
-    @get:jakarta.persistence.Transient
+    @get:Transient
     val displayName: String
         get() = when (kind) {
             MatchParticipantKind.PLAYER -> "${requireNotNull(firstName)} ${requireNotNull(lastName)}"

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchTeam.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/model/MatchTeam.kt
@@ -25,6 +25,9 @@ data class MatchTeam(
     @Column(name = "team_id")
     val teamId: UUID,
 
+    @Column(name = "team_name", nullable = false, length = 255)
+    val teamName: String,
+
     @Column(nullable = false)
     val position: Int,
 

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/MatchServiceImpl.kt
@@ -13,6 +13,7 @@ import com.github.mihanizzm.ultistats.repository.jpa.SpringDataEventRepository
 import com.github.mihanizzm.ultistats.repository.jpa.SpringDataMatchParticipantRepository
 import com.github.mihanizzm.ultistats.repository.jpa.SpringDataMatchRepository
 import com.github.mihanizzm.ultistats.repository.jpa.SpringDataMatchTeamRepository
+import com.github.mihanizzm.ultistats.repository.jpa.SpringDataPlayerRepository
 import com.github.mihanizzm.ultistats.repository.jpa.SpringDataTeamRepository
 import com.github.mihanizzm.ultistats.service.result.MatchCommandResult
 import com.github.mihanizzm.ultistats.validation.event.EventSequenceDecision
@@ -33,6 +34,7 @@ class MatchServiceImpl(
     private val matchTeamRepository: SpringDataMatchTeamRepository,
     private val matchParticipantRepository: SpringDataMatchParticipantRepository,
     private val teamPlayerRepository: SpringDataTeamPlayerRepository,
+    private val playerRepository: SpringDataPlayerRepository,
     private val eventRepository: SpringDataEventRepository,
     private val teamRepository: SpringDataTeamRepository,
     private val lifecyclePolicy: MatchLifecyclePolicy,
@@ -166,6 +168,7 @@ class MatchServiceImpl(
         }
         return copy(
             teamIds = matchTeams.map { it.teamId },
+            teamNamesById = matchTeams.associate { it.teamId to it.teamName },
             teamScores = matchTeams.map { TeamScore(it.teamId, it.score) }.toMutableList(),
             participantsByTeam = matchParticipants
                 .sortedWith(
@@ -189,12 +192,31 @@ class MatchServiceImpl(
         matchParticipantRepository.flush()
         matchTeamRepository.deleteAllByMatchId(matchId)
         matchTeamRepository.flush()
+        val teamsById = teamRepository.findAllByIdInAndDeletedAtIsNull(teamIds).associateBy { it.id }
         matchTeamRepository.saveAll(teamIds.mapIndexed { index, teamId ->
-            MatchTeam(matchId, teamId, index + 1)
+            MatchTeam(
+                matchId = matchId,
+                teamId = teamId,
+                teamName = teamsById.getValue(teamId).name,
+                position = index + 1,
+            )
         })
+        val membershipsByTeam = teamIds.associateWith(teamPlayerRepository::findAllByTeamIdAndDeletedAtIsNull)
+        val playersById = playerRepository.findAllByIdInAndDeletedAtIsNull(
+            membershipsByTeam.values.flatten().map { it.playerId }.distinct(),
+        ).associateBy { it.id }
         val participants = teamIds.flatMap { teamId ->
-            val players = teamPlayerRepository.findAllByTeamIdAndDeletedAtIsNull(teamId).map { membership ->
-                MatchParticipant.player(matchId, teamId, membership.playerId, membership.number)
+            val players = membershipsByTeam.getValue(teamId).mapNotNull { membership ->
+                playersById[membership.playerId]?.let { player ->
+                    MatchParticipant.player(
+                        matchId = matchId,
+                        teamId = teamId,
+                        playerId = player.id,
+                        firstName = player.firstName,
+                        lastName = player.lastName,
+                        number = membership.number,
+                    )
+                }
             }
             players + (1..2).map { slot -> MatchParticipant.unknown(matchId, teamId, slot) }
         }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/StatisticsService.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/StatisticsService.kt
@@ -1,10 +1,8 @@
 package com.github.mihanizzm.ultistats.service.statistics
 
+import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
-import java.util.UUID
 
 interface StatisticsService {
-    fun emptyStatistics(teamIds: List<UUID>): MatchStatistics
-
-    fun recalculateMatchStatistics(matchId: UUID): MatchStatistics
+    fun recalculateMatchStatistics(match: Match): MatchStatistics
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/StatisticsServiceImpl.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/service/statistics/StatisticsServiceImpl.kt
@@ -1,43 +1,21 @@
 package com.github.mihanizzm.ultistats.service.statistics
 
+import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
 import com.github.mihanizzm.ultistats.model.statistics.PlayerStatistics
 import com.github.mihanizzm.ultistats.model.statistics.TeamStatistics
-import com.github.mihanizzm.ultistats.service.MatchService
-import com.github.mihanizzm.ultistats.service.PlayerService
-import com.github.mihanizzm.ultistats.service.TeamPlayerService
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 @Suppress("unused")
 class StatisticsServiceImpl(
-    private val matchService: MatchService,
-    private val playerService: PlayerService,
-    private val teamPlayerService: TeamPlayerService,
     private val statisticsAggregatorList: List<StatisticsAggregator>,
 ) : StatisticsService {
-    override fun emptyStatistics(teamIds: List<UUID>): MatchStatistics {
-        val teamStats = teamIds
-            .map { TeamStatistics(teamId = it) }
-
-        val playerIds = teamIds.flatMap { teamPlayerService.getByTeamId(it).map { membership -> membership.playerId } }
-        val playersStats = playerService.getAllByIds(playerIds.distinct())
-            .map { PlayerStatistics(participantId = it.id) }
-
-        return MatchStatistics(
-            playerStatistics = playersStats,
-            teamStatistics = teamStats,
-        )
-    }
-
-    override fun recalculateMatchStatistics(matchId: UUID): MatchStatistics {
-        val match = matchService.getOrThrow(matchId)
-        val teamIds = match.teamIds
+    override fun recalculateMatchStatistics(match: Match): MatchStatistics {
         val initialStatistics = MatchStatistics(
             playerStatistics = match.participantsByTeam.values.flatten()
                 .map { PlayerStatistics(participantId = it.participantId) },
-            teamStatistics = teamIds.map { TeamStatistics(teamId = it) },
+            teamStatistics = match.teamIds.map { TeamStatistics(teamId = it) },
         )
         val teamByParticipantId = match.participantsByTeam.flatMap { (teamId, participants) ->
             participants.map { it.participantId to teamId }

--- a/src/main/resources/db/migration/V3__add_match_display_snapshots.sql
+++ b/src/main/resources/db/migration/V3__add_match_display_snapshots.sql
@@ -1,0 +1,30 @@
+ALTER TABLE match_teams ADD COLUMN team_name VARCHAR(255);
+
+UPDATE match_teams
+SET team_name = (
+    SELECT teams.name FROM teams WHERE teams.id = match_teams.team_id
+);
+
+ALTER TABLE match_teams ALTER COLUMN team_name SET NOT NULL;
+
+ALTER TABLE match_participants ADD COLUMN first_name VARCHAR(255);
+ALTER TABLE match_participants ADD COLUMN last_name VARCHAR(255);
+
+UPDATE match_participants
+SET first_name = (
+        SELECT players.first_name FROM players
+        WHERE players.id = match_participants.participant_id
+    ),
+    last_name = (
+        SELECT players.last_name FROM players
+        WHERE players.id = match_participants.participant_id
+    )
+WHERE kind = 'PLAYER';
+
+ALTER TABLE match_participants
+    ADD CONSTRAINT chk_match_participant_display_snapshot
+    CHECK (
+        (kind = 'PLAYER' AND first_name IS NOT NULL AND last_name IS NOT NULL)
+        OR
+        (kind = 'UNKNOWN' AND first_name IS NULL AND last_name IS NULL)
+    );

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/MatchAbstractTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/MatchAbstractTest.kt
@@ -151,6 +151,6 @@ abstract class MatchAbstractTest {
     protected fun recalculateTestMatchStatistics(): MatchStatistics {
         MATCH.events.toList().forEach { eventService.create(it, MATCH.id) }
         MATCH.events.clear()
-        return statisticsService.recalculateMatchStatistics(MATCH.id)
+        return statisticsService.recalculateMatchStatistics(matchService.getOrThrow(MATCH.id))
     }
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/RelationalModelIntegrationTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/RelationalModelIntegrationTest.kt
@@ -187,7 +187,7 @@ class RelationalModelIntegrationTest {
             match.id,
         )
         eventService.create(assertNotNull(event), match.id)
-        val statistics = statisticsService.recalculateMatchStatistics(match.id)
+        val statistics = statisticsService.recalculateMatchStatistics(matchService.getOrThrow(match.id))
 
         assertEquals(
             1,

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/EventControllerTest.kt
@@ -500,7 +500,7 @@ class EventControllerTest {
             .andReturn().response.contentAsString
         val eventId = objectMapper.readTree(created).get("id").asText()
 
-        val unresolved = statisticsService.recalculateMatchStatistics(match.id)
+        val unresolved = statisticsService.recalculateMatchStatistics(matchService.getOrThrow(match.id))
         assertEquals(1, unresolved.playerStatistics.single { it.participantId == unknowns[0].participantId }.attack.passes)
         assertEquals(1, unresolved.playerStatistics.single { it.participantId == unknowns[1].participantId }.attack.catches)
 
@@ -514,7 +514,7 @@ class EventControllerTest {
             .andExpect(jsonPath("$.fromParticipantId").value(player1.id.toString()))
             .andExpect(jsonPath("$.toParticipantId").value(unknowns[1].participantId.toString()))
 
-        val partiallyCorrected = statisticsService.recalculateMatchStatistics(match.id)
+        val partiallyCorrected = statisticsService.recalculateMatchStatistics(matchService.getOrThrow(match.id))
         assertEquals(0, partiallyCorrected.playerStatistics.single { it.participantId == unknowns[0].participantId }.attack.passes)
         assertEquals(1, partiallyCorrected.playerStatistics.single { it.participantId == unknowns[1].participantId }.attack.catches)
         assertEquals(1, partiallyCorrected.playerStatistics.single { it.participantId == player1.id }.attack.passes)
@@ -529,7 +529,7 @@ class EventControllerTest {
             .andExpect(jsonPath("$.fromParticipantId").value(player1.id.toString()))
             .andExpect(jsonPath("$.toParticipantId").value(player2.id.toString()))
 
-        val corrected = statisticsService.recalculateMatchStatistics(match.id)
+        val corrected = statisticsService.recalculateMatchStatistics(matchService.getOrThrow(match.id))
         assertEquals(0, corrected.playerStatistics.single { it.participantId == unknowns[0].participantId }.attack.passes)
         assertEquals(0, corrected.playerStatistics.single { it.participantId == unknowns[1].participantId }.attack.catches)
         assertEquals(1, corrected.playerStatistics.single { it.participantId == player1.id }.attack.passes)

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
@@ -13,6 +13,7 @@ import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
 import com.github.mihanizzm.ultistats.service.TeamService
 import com.github.mihanizzm.ultistats.service.TeamPlayerService
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -79,12 +80,14 @@ class MatchControllerTest {
             .andExpect(jsonPath("$.teams[0].participants[0].firstName").value("Игрок"))
             .andExpect(jsonPath("$.teams[0].participants[0].lastName").value("Один"))
             .andExpect(jsonPath("$.teams[0].participants[0].displayName").value("Игрок Один"))
+            .andExpect(jsonPath("$.teams[0].participants[0].unknownSlot").value(nullValue()))
             .andExpect(jsonPath("$.teams[0].participants[0].playerId").doesNotExist())
             .andExpect(jsonPath("$.teams[0].participants[2].kind").value("UNKNOWN"))
             .andExpect(jsonPath("$.teams[0].participants[2].unknownSlot").value(1))
-            .andExpect(jsonPath("$.teams[0].participants[2].firstName").doesNotExist())
-            .andExpect(jsonPath("$.teams[0].participants[2].lastName").doesNotExist())
+            .andExpect(jsonPath("$.teams[0].participants[2].firstName").value(nullValue()))
+            .andExpect(jsonPath("$.teams[0].participants[2].lastName").value(nullValue()))
             .andExpect(jsonPath("$.teams[0].participants[2].displayName").value("Неизвестный игрок 1"))
+            .andExpect(jsonPath("$.teams[0].participants[2].number").value(nullValue()))
             .andExpect(jsonPath("$.teams[0].participants[2].playerId").doesNotExist())
             .andExpect(jsonPath("$.teams[0].participants[3].kind").value("UNKNOWN"))
             .andExpect(jsonPath("$.teams[0].participants[3].unknownSlot").value(2))
@@ -243,6 +246,25 @@ class MatchControllerTest {
             .andExpect(jsonPath("$.content.length()").value(2))
             .andExpect(jsonPath("$.totalElements").value(2))
             .andExpect(jsonPath("$.currentPage").value(0))
+    }
+
+    @Test
+    fun `Имя команды в списке матчей не меняется после переименования`() {
+        val team1 = createTestTeam("Original team 1")
+        val team2 = createTestTeam("Original team 2")
+        val created = mockMvc.perform(
+            post("/api/v1/matches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(CreateMatchRequest(listOf(team1.id, team2.id)))),
+        ).andExpect(status().isCreated).andReturn()
+        val matchId = objectMapper.readTree(created.response.contentAsString).get("id").asText()
+
+        teamService.update(team1.copy(name = "Renamed team"))
+
+        mockMvc.perform(get("/api/v1/matches"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(matchId))
+            .andExpect(jsonPath("$.content[0].teams[0].teamName").value("Original team 1"))
     }
 
     @Test

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/MatchControllerTest.kt
@@ -76,15 +76,96 @@ class MatchControllerTest {
             .andExpect(jsonPath("$.teams[0].participants.length()").value(4))
             .andExpect(jsonPath("$.teams[0].participants[0].kind").value("PLAYER"))
             .andExpect(jsonPath("$.teams[0].participants[0].participantId").exists())
+            .andExpect(jsonPath("$.teams[0].participants[0].firstName").value("Игрок"))
+            .andExpect(jsonPath("$.teams[0].participants[0].lastName").value("Один"))
+            .andExpect(jsonPath("$.teams[0].participants[0].displayName").value("Игрок Один"))
             .andExpect(jsonPath("$.teams[0].participants[0].playerId").doesNotExist())
             .andExpect(jsonPath("$.teams[0].participants[2].kind").value("UNKNOWN"))
             .andExpect(jsonPath("$.teams[0].participants[2].unknownSlot").value(1))
+            .andExpect(jsonPath("$.teams[0].participants[2].firstName").doesNotExist())
+            .andExpect(jsonPath("$.teams[0].participants[2].lastName").doesNotExist())
+            .andExpect(jsonPath("$.teams[0].participants[2].displayName").value("Неизвестный игрок 1"))
             .andExpect(jsonPath("$.teams[0].participants[2].playerId").doesNotExist())
             .andExpect(jsonPath("$.teams[0].participants[3].kind").value("UNKNOWN"))
             .andExpect(jsonPath("$.teams[0].participants[3].unknownSlot").value(2))
             .andExpect(jsonPath("$.teams[1].participants.length()").value(4))
             .andExpect(jsonPath("$.eventCount").value(0))
             .andExpect(jsonPath("$.diskHolderId").doesNotExist())
+    }
+
+    @Test
+    fun `Имена матча не меняются после редактирования справочников`() {
+        val team1 = createTestTeam("Original team 1")
+        val team2 = createTestTeam("Original team 2")
+        val firstMembership = teamPlayerService.getByTeamId(team1.id).first { it.number == 1 }
+        val player = requireNotNull(playerService.get(firstMembership.playerId))
+        val request = CreateMatchRequest(teamIds = listOf(team1.id, team2.id))
+        val created = mockMvc.perform(
+            post("/api/v1/matches")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        ).andExpect(status().isCreated).andReturn()
+        val createdJson = objectMapper.readTree(created.response.contentAsString)
+        val matchId = createdJson.get("id").asText()
+        val originalNumber = createdJson.at("/teams/0/participants/0/number").asInt()
+
+        teamService.update(team1.copy(name = "Renamed team"))
+        playerService.update(player.copy(firstName = "Renamed", lastName = "Player"))
+        teamPlayerService.add(team1.id, player.id, originalNumber + 10)
+        playerService.delete(player.id)
+
+        mockMvc.perform(
+            put("/api/v1/matches/$matchId")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(UpdateMatchRequest(teamIds = listOf(team1.id, team2.id)))),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.teams[0].teamName").value("Original team 1"))
+            .andExpect(jsonPath("$.teams[0].participants[0].displayName")
+                .value("${player.firstName} ${player.lastName}"))
+            .andExpect(jsonPath("$.teams[0].participants[0].number").value(originalNumber))
+
+        mockMvc.perform(get("/api/v1/matches/$matchId"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.teams[0].teamName").value("Original team 1"))
+            .andExpect(jsonPath("$.teams[0].participants[0].firstName").value(player.firstName))
+            .andExpect(jsonPath("$.teams[0].participants[0].lastName").value(player.lastName))
+            .andExpect(jsonPath("$.teams[0].participants[0].displayName")
+                .value("${player.firstName} ${player.lastName}"))
+            .andExpect(jsonPath("$.teams[0].participants[0].number").value(originalNumber))
+    }
+
+    @Test
+    fun `Замена команды в запланированном матче создает новый снимок`() {
+        val team1 = createTestTeam("Команда 1")
+        val removedTeam = createTestTeam("Удаленная команда")
+        val replacementTeam = createTestTeam("Команда замены")
+        teamPlayerService.getByTeamId(replacementTeam.id).forEach { membership ->
+            val player = requireNotNull(playerService.get(membership.playerId))
+            playerService.update(
+                player.copy(firstName = "Замена", lastName = "Игрок ${membership.number}"),
+            )
+        }
+        val match = createTestMatch(team1, removedTeam)
+        val updateRequest = UpdateMatchRequest(teamIds = listOf(team1.id, replacementTeam.id))
+
+        mockMvc.perform(
+            put("/api/v1/matches/${match.id}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.teams[1].teamId").value(replacementTeam.id.toString()))
+            .andExpect(jsonPath("$.teams[1].teamName").value("Команда замены"))
+            .andExpect(jsonPath("$.teams[1].participants[0].displayName").value("Замена Игрок 1"))
+            .andExpect(jsonPath("$.teams[1].participants[1].displayName").value("Замена Игрок 2"))
+
+        mockMvc.perform(get("/api/v1/matches/${match.id}"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.teams[1].teamId").value(replacementTeam.id.toString()))
+            .andExpect(jsonPath("$.teams[1].teamName").value("Команда замены"))
+            .andExpect(jsonPath("$.teams[1].participants[0].displayName").value("Замена Игрок 1"))
+            .andExpect(jsonPath("$.teams[1].participants[1].displayName").value("Замена Игрок 2"))
     }
 
     @Test

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -7,24 +7,25 @@ import com.github.mihanizzm.ultistats.model.Player
 import com.github.mihanizzm.ultistats.model.Team
 import com.github.mihanizzm.ultistats.model.events.EventType
 import com.github.mihanizzm.ultistats.model.events.OnePlayerEvent
-import com.github.mihanizzm.ultistats.model.events.SystemEvent
 import com.github.mihanizzm.ultistats.model.events.TeamEvent
 import com.github.mihanizzm.ultistats.model.events.TwoPlayerEvent
 import com.github.mihanizzm.ultistats.service.EventService
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.PlayerService
-import com.github.mihanizzm.ultistats.service.TeamService
 import com.github.mihanizzm.ultistats.service.TeamPlayerService
+import com.github.mihanizzm.ultistats.service.TeamService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
-import java.time.Duration
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.Instant
 import java.util.UUID
 
@@ -72,15 +73,35 @@ class StatisticsControllerTest {
         players1 = p1
         players2 = p2
         match = createTestMatch(team1, team2)
-        matchService.startMatch(match.id, Instant.parse("2025-01-01T00:00:00Z"))
+        matchService.startMatch(match.id, MATCH_STARTED_AT)
     }
 
     @Test
-    fun `Получение статистики пустого матча возвращает 200`() {
+    fun `Статистика события возвращает сгруппированный контракт со снимками и миллисекундами`() {
+        eventService.create(OnePlayerEvent(players1[0].id, MATCH_STARTED_AT.plusSeconds(1), EventType.PULL), match.id)
+        eventService.create(OnePlayerEvent(players1[0].id, MATCH_STARTED_AT.plusSeconds(2), EventType.PICKUP), match.id)
+        eventService.create(TwoPlayerEvent(players1[0].id, players1[1].id, MATCH_STARTED_AT.plusSeconds(3), EventType.PASS), match.id)
+
+        teamService.update(team1.copy(name = "Переименованная команда"))
+        playerService.update(players1[0].copy(firstName = "Новый", lastName = "Игрок"))
+
         mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.playerStatistics").isArray)
-            .andExpect(jsonPath("$.teamStatistics").isArray)
+            .andExpect(jsonPath("$.matchId").value(match.id.toString()))
+            .andExpect(jsonPath("$.teams.length()").value(2))
+            .andExpect(jsonPath("$.teams[0].teamId").value(team1.id.toString()))
+            .andExpect(jsonPath("$.teams[0].teamName").value("Команда 1"))
+            .andExpect(jsonPath("$.teams[1].teamId").value(team2.id.toString()))
+            .andExpect(jsonPath("$.teams[1].teamName").value("Команда 2"))
+            .andExpect(jsonPath("$.teams[0].participants[0].firstName").value("Игрок"))
+            .andExpect(jsonPath("$.teams[0].participants[0].lastName").value("Один"))
+            .andExpect(jsonPath("$.teams[0].participants[0].displayName").value("Игрок Один"))
+            .andExpect(jsonPath("$.teams[0].attack.allPasses").value(1))
+            .andExpect(jsonPath("$.time.totalTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[0].time.possessionTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[0].participants[0].time.possessionTimeMs").isNumber)
+            .andExpect(jsonPath("$.playerStatistics").doesNotExist())
+            .andExpect(jsonPath("$.teamStatistics").doesNotExist())
     }
 
     @Test
@@ -107,9 +128,8 @@ class StatisticsControllerTest {
     }
 
     @Test
-    fun `Статистика использует контракт участников матча и включает неизвестных`() {
-        val participants = matchService.getOrThrow(match.id).participantsByTeam.values.flatten()
-        val unknownParticipantIds = participants
+    fun `Статистика включает четыре неизвестных участника с явными nullable полями`() {
+        val expectedUnknownIds = matchService.getOrThrow(match.id).participantsByTeam.values.flatten()
             .filter { it.kind == MatchParticipantKind.UNKNOWN }
             .map { it.participantId.toString() }
             .toSet()
@@ -117,85 +137,90 @@ class StatisticsControllerTest {
         val response = mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
             .andExpect(status().isOk)
             .andReturn()
-        val playerStatistics = objectMapper.readTree(response.response.contentAsString).get("playerStatistics")
+        val teams = objectMapper.readTree(response.response.contentAsString).get("teams")
+        val participants = teams.flatMap { team -> team.get("participants").toList() }
+        val unknowns = participants.filter { it.get("kind").asText() == MatchParticipantKind.UNKNOWN.name }
 
-        assertThat(playerStatistics).allSatisfy { statistics ->
-            assertThat(statistics.hasNonNull("participantId")).isTrue()
-            assertThat(statistics.has("playerId")).isFalse()
+        assertThat(participants).allSatisfy { participant ->
+            assertThat(participant.hasNonNull("participantId")).isTrue()
+            assertThat(participant.has("playerId")).isFalse()
         }
-        assertThat(playerStatistics.map { it.get("participantId").asText() }).containsExactlyInAnyOrderElementsOf(
-            participants.map { it.participantId.toString() },
-        )
-        assertThat(playerStatistics.map { it.get("participantId").asText() }.toSet())
-            .containsAll(unknownParticipantIds)
-        assertThat(unknownParticipantIds).hasSize(4)
+        assertThat(unknowns.map { it.get("participantId").asText() })
+            .containsExactlyInAnyOrderElementsOf(expectedUnknownIds)
+        assertThat(unknowns).hasSize(4)
+        assertThat(unknowns).allSatisfy { unknown ->
+            assertThat(unknown.has("firstName")).isTrue()
+            assertThat(unknown.get("firstName").isNull).isTrue()
+            assertThat(unknown.has("lastName")).isTrue()
+            assertThat(unknown.get("lastName").isNull).isTrue()
+            assertThat(unknown.has("number")).isTrue()
+            assertThat(unknown.get("number").isNull).isTrue()
+            assertThat(unknown.get("displayName").asText())
+                .isEqualTo("Неизвестный игрок ${unknown.get("unknownSlot").asInt()}")
+        }
     }
 
     @Test
-    fun `Получение статистики несуществующего матча возвращает 404`() {
-        mockMvc.perform(get("/api/v1/matches/${UUID.randomUUID()}/statistics"))
+    fun `Несуществующий матч возвращает структурированный 404`() {
+        val missingId = UUID.randomUUID()
+        val instance = "/api/v1/matches/$missingId/statistics"
+
+        mockMvc.perform(get(instance))
             .andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+            .andExpect(jsonPath("$.title").value("Resource not found"))
+            .andExpect(jsonPath("$.detail").value("Match $missingId not found"))
+            .andExpect(jsonPath("$.instance").value(instance))
     }
 
     @Test
-    fun `Статистика учитывает события матча`() {
-        val player1 = players1[0]
-        val player2 = players1[1]
-        val now = Instant.now()
+    fun `Мягко удаленный матч возвращает структурированный 404`() {
+        matchService.delete(match.id)
+        val instance = "/api/v1/matches/${match.id}/statistics"
 
-        // Добавляем валидную последовательность: пулл, подбор и пас
-        eventService.create(
-            OnePlayerEvent(player1.id, now, EventType.PULL),
-            match.id
-        )
-        eventService.create(
-            OnePlayerEvent(player1.id, now.plusSeconds(1), EventType.PICKUP),
-            match.id
-        )
-        eventService.create(
-            TwoPlayerEvent(player1.id, player2.id, now.plusSeconds(2), EventType.PASS),
-            match.id
-        )
+        mockMvc.perform(get(instance))
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+            .andExpect(jsonPath("$.instance").value(instance))
+    }
+
+    @Test
+    fun `Временная статистика публикуется числом миллисекунд`() {
+        eventService.create(OnePlayerEvent(players1[0].id, MATCH_STARTED_AT.plusSeconds(1), EventType.PULL), match.id)
+        eventService.create(OnePlayerEvent(players2[0].id, MATCH_STARTED_AT.plusSeconds(10), EventType.PICKUP), match.id)
+        eventService.create(TeamEvent(team2.id, MATCH_STARTED_AT.plusSeconds(15), EventType.TIMEOUT_START), match.id)
+        eventService.create(TeamEvent(team2.id, MATCH_STARTED_AT.plusSeconds(75), EventType.TIMEOUT_END), match.id)
+        eventService.create(TwoPlayerEvent(players2[0].id, players2[1].id, MATCH_STARTED_AT.plusSeconds(90), EventType.PASS), match.id)
+        eventService.create(TwoPlayerEvent(players2[1].id, players2[2].id, MATCH_STARTED_AT.plusSeconds(100), EventType.GOAL), match.id)
 
         mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.teamStatistics[?(@.teamId=='${team1.id}')].attack.allPasses").value(1))
-            .andExpect(jsonPath("$.teamStatistics[?(@.teamId=='${team1.id}')].attack.completePasses").value(1))
+            .andExpect(jsonPath("$.time.totalTimeMs").isNumber)
+            .andExpect(jsonPath("$.time.betweenPointsTimeMs").isNumber)
+            .andExpect(jsonPath("$.time.timeoutTimeMs").isNumber)
+            .andExpect(jsonPath("$.time.halftimeTimeMs").isNumber)
+            .andExpect(jsonPath("$.time.pureGameTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[1].time.possessionTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[1].time.betweenPointsTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[1].time.timeoutTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[1].participants[0].time.possessionTimeMs").isNumber)
+            .andExpect(jsonPath("$.teams[1].participants[0].time.averagePossessionTimeMs").isNumber)
     }
 
     @Test
-    fun `Duration сериализуется в ISO-8601 строку`() {
-        // Создаём события с таймаутом для проверки timeStatistics
-        val now = Instant.now()
-        eventService.create(OnePlayerEvent(players1[0].id, now, EventType.PULL), match.id)
-        eventService.create(OnePlayerEvent(players2[0].id, now.plusSeconds(10), EventType.PICKUP), match.id)
-        eventService.create(TeamEvent(team2.id, now.plusSeconds(15), EventType.TIMEOUT_START), match.id)
-        eventService.create(TeamEvent(team2.id, now.plusSeconds(75), EventType.TIMEOUT_END), match.id)
-        eventService.create(TwoPlayerEvent(players2[0].id, players2[1].id, now.plusSeconds(90), EventType.PASS), match.id)
-        eventService.create(TwoPlayerEvent(players2[1].id, players2[2].id, now.plusSeconds(100), EventType.GOAL), match.id)
-
-        val result = mockMvc.perform(get("/api/v1/matches/${match.id}/statistics"))
+    fun `OpenAPI документирует стабильный ответ и ProblemDetail`() {
+        mockMvc.perform(get("/v3/api-docs"))
             .andExpect(status().isOk)
-            .andReturn()
-
-        val json = result.response.contentAsString
-        val tree = objectMapper.readTree(json)
-
-        // Проверяем, что timeStatistics поля - строки в ISO-8601 формате
-        val timeStats = tree.get("timeStatistics")
-        assertThat(timeStats.get("timeSpentOnTimeouts").isTextual).isTrue()
-        assertThat(timeStats.get("timeSpentOnTimeouts").asText()).isNotEmpty()
-        assertThat(timeStats.get("timeSpentBetweenPoints").isTextual).isTrue()
-        assertThat(timeStats.get("pureGameTime").isTextual).isTrue()
-
-        // Проверяем, что поля времени в teamStatistics тоже строки
-        val team2Stats = tree.get("teamStatistics").find { it.get("teamId").asText() == team2.id.toString() }
-        assertThat(team2Stats?.get("time")?.get("totalPossessionTime")?.isTextual).isTrue()
-        assertThat(team2Stats?.get("time")?.get("totalTimeSpentOnTimeouts")?.isTextual).isTrue()
-
-        // Проверяем, что поля времени в playerStatistics тоже строки
-        val playerStats = tree.get("playerStatistics").first()
-        assertThat(playerStats.get("time").get("totalPossessionTime").isTextual).isTrue()
+            .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['200'].content['application/json'].schema['\$ref']")
+                .value("#/components/schemas/MatchStatisticsResponse"))
+            .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['200'].content['application/json'].example.time.totalTimeMs").isNumber)
+            .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['200'].content['application/json'].example.teams[0].participants[0].displayName").value("Ivan Ivanov"))
+            .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['200'].content['application/json'].example.teams[0].participants[0].attack.passes").isNumber)
+            .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['200'].content['application/json'].example.teams[0].participants[0].time.possessionTimeMs").isNumber)
+            .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['404'].content['application/problem+json'].schema['\$ref']")
+                .value("#/components/schemas/ProblemDetail"))
     }
 
     private fun createTestTeam(name: String): Pair<Team, List<Player>> {
@@ -205,10 +230,7 @@ class StatisticsControllerTest {
             Player(UUID.randomUUID(), "Игрок", "Два"),
             Player(UUID.randomUUID(), "Игрок", "Три"),
         )
-        val team = Team(
-            id = teamId,
-            name = name,
-        )
+        val team = Team(id = teamId, name = name)
         teamService.create(team)
         players.forEach { playerService.create(it) }
         players.forEachIndexed { index, player -> teamPlayerService.add(teamId, player.id, index + 1) }
@@ -216,11 +238,12 @@ class StatisticsControllerTest {
     }
 
     private fun createTestMatch(team1: Team, team2: Team): Match {
-        val match = Match(
-            id = UUID.randomUUID(),
-            teamIds = listOf(team1.id, team2.id),
-        )
+        val match = Match(id = UUID.randomUUID(), teamIds = listOf(team1.id, team2.id))
         matchService.create(match)
         return match
+    }
+
+    companion object {
+        private val MATCH_STARTED_AT = Instant.parse("2025-01-01T00:00:00Z")
     }
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacadeTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacadeTest.kt
@@ -1,0 +1,46 @@
+package com.github.mihanizzm.ultistats.facade
+
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.mapper.StatisticsResponseMapper
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
+import com.github.mihanizzm.ultistats.service.MatchService
+import com.github.mihanizzm.ultistats.service.statistics.StatisticsService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.same
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.`when`
+import java.util.UUID
+
+class StatisticsFacadeTest {
+    private val matchService = mock(MatchService::class.java)
+    private val statisticsService = mock(StatisticsService::class.java)
+    private val responseMapper = mock(StatisticsResponseMapper::class.java)
+    private val facade = StatisticsFacade(matchService, statisticsService, responseMapper)
+
+    @Test
+    fun `loads match once and propagates the same instance through calculation and mapping`() {
+        val match = Match(id = UUID.randomUUID(), teamIds = emptyList())
+        val statistics = MatchStatistics(playerStatistics = emptyList(), teamStatistics = emptyList())
+        val response = MatchStatisticsResponse(
+            matchId = match.id,
+            teams = emptyList(),
+            time = MatchTimeStatisticsResponse(0, 0, 0, 0, 0),
+        )
+        `when`(matchService.get(match.id)).thenReturn(match)
+        `when`(statisticsService.recalculateMatchStatistics(same(match) ?: match)).thenReturn(statistics)
+        `when`(responseMapper.toResponse(same(match) ?: match, same(statistics) ?: statistics)).thenReturn(response)
+
+        assertThat(facade.get(match.id)).isSameAs(response)
+
+        verify(matchService, times(1)).get(match.id)
+        verify(statisticsService, times(1)).recalculateMatchStatistics(same(match) ?: match)
+        verify(responseMapper, times(1)).toResponse(same(match) ?: match, same(statistics) ?: statistics)
+        verifyNoMoreInteractions(matchService, statisticsService, responseMapper)
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/mapper/StatisticsResponseMapperTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/mapper/StatisticsResponseMapperTest.kt
@@ -1,0 +1,352 @@
+package com.github.mihanizzm.ultistats.mapper
+
+import com.github.mihanizzm.ultistats.dto.response.statistics.DefenseStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.ParticipantStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.PlayerAttackStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.PlayerTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamAttackStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.model.Match
+import com.github.mihanizzm.ultistats.model.MatchParticipant
+import com.github.mihanizzm.ultistats.model.MatchParticipantKind
+import com.github.mihanizzm.ultistats.model.statistics.DefenseStatistics
+import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
+import com.github.mihanizzm.ultistats.model.statistics.MatchTimeStatistics
+import com.github.mihanizzm.ultistats.model.statistics.PlayerAttackStatistics
+import com.github.mihanizzm.ultistats.model.statistics.PlayerStatistics
+import com.github.mihanizzm.ultistats.model.statistics.PlayerTimeStatistics
+import com.github.mihanizzm.ultistats.model.statistics.TeamAttackStatistics
+import com.github.mihanizzm.ultistats.model.statistics.TeamStatistics
+import com.github.mihanizzm.ultistats.model.statistics.TeamTimeStatistics
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.UUID
+
+class StatisticsResponseMapperTest {
+    private val mapper = StatisticsResponseMapper()
+
+    @Test
+    fun `maps statistics by identifiers and preserves match ordering`() {
+        val response = mapper.toResponse(match(), reversedStatistics())
+
+        assertThat(response).isEqualTo(
+            MatchStatisticsResponse(
+                matchId = MATCH_ID,
+                teams = listOf(
+                    TeamStatisticsResponse(
+                        teamId = TEAM_1_ID,
+                        teamName = "Flying Bears",
+                        attack = TeamAttackStatisticsResponse(
+                            score = 7,
+                            completePasses = 31,
+                            allPasses = 37,
+                            pulls = 8,
+                            bricks = 2,
+                            possessions = 14,
+                        ),
+                        defense = DefenseStatisticsResponse(
+                            blocks = 3,
+                            blocksAsMarker = 1,
+                            blocksAsFieldPlayer = 2,
+                            interceptions = 4,
+                            callahans = 1,
+                        ),
+                        time = TeamTimeStatisticsResponse(
+                            possessionTimeMs = 42_000L,
+                            betweenPointsTimeMs = 12_000L,
+                            timeoutTimeMs = 3_000L,
+                        ),
+                        participants = listOf(
+                            ParticipantStatisticsResponse(
+                                participantId = PLAYER_ID,
+                                kind = MatchParticipantKind.PLAYER,
+                                unknownSlot = null,
+                                firstName = "Ivan",
+                                lastName = "Ivanov",
+                                displayName = "Ivan Ivanov",
+                                number = 17,
+                                attack = PlayerAttackStatisticsResponse(
+                                    passes = 12,
+                                    catches = 11,
+                                    assists = 3,
+                                    goals = 2,
+                                    dropsOnMarker = 1,
+                                    dropsOnField = 2,
+                                    incompletePasses = 4,
+                                    callahanDrops = 1,
+                                    discPossessions = 15,
+                                    pulls = 5,
+                                    bricks = 1,
+                                ),
+                                defense = DefenseStatisticsResponse(
+                                    blocks = 2,
+                                    blocksAsMarker = 1,
+                                    blocksAsFieldPlayer = 1,
+                                    interceptions = 3,
+                                    callahans = 1,
+                                ),
+                                time = PlayerTimeStatisticsResponse(
+                                    possessionTimeMs = 21_000L,
+                                    averagePossessionTimeMs = 1_500L,
+                                ),
+                            ),
+                            ParticipantStatisticsResponse(
+                                participantId = UNKNOWN_ID,
+                                kind = MatchParticipantKind.UNKNOWN,
+                                unknownSlot = 1,
+                                firstName = null,
+                                lastName = null,
+                                displayName = "Неизвестный игрок 1",
+                                number = null,
+                                attack = PlayerAttackStatisticsResponse(
+                                    passes = 6,
+                                    catches = 5,
+                                    assists = 1,
+                                    goals = 1,
+                                    dropsOnMarker = 2,
+                                    dropsOnField = 3,
+                                    incompletePasses = 4,
+                                    callahanDrops = 0,
+                                    discPossessions = 9,
+                                    pulls = 2,
+                                    bricks = 1,
+                                ),
+                                defense = DefenseStatisticsResponse(
+                                    blocks = 1,
+                                    blocksAsMarker = 0,
+                                    blocksAsFieldPlayer = 1,
+                                    interceptions = 2,
+                                    callahans = 0,
+                                ),
+                                time = PlayerTimeStatisticsResponse(
+                                    possessionTimeMs = 9_000L,
+                                    averagePossessionTimeMs = 1_000L,
+                                ),
+                            ),
+                        ),
+                    ),
+                    TeamStatisticsResponse(
+                        teamId = TEAM_2_ID,
+                        teamName = "Swift Foxes",
+                        attack = TeamAttackStatisticsResponse(
+                            score = 5,
+                            completePasses = 24,
+                            allPasses = 29,
+                            pulls = 6,
+                            bricks = 1,
+                            possessions = 12,
+                        ),
+                        defense = DefenseStatisticsResponse(
+                            blocks = 2,
+                            blocksAsMarker = 1,
+                            blocksAsFieldPlayer = 1,
+                            interceptions = 2,
+                            callahans = 0,
+                        ),
+                        time = TeamTimeStatisticsResponse(
+                            possessionTimeMs = 36_000L,
+                            betweenPointsTimeMs = 10_000L,
+                            timeoutTimeMs = 2_000L,
+                        ),
+                        participants = emptyList(),
+                    ),
+                ),
+                time = MatchTimeStatisticsResponse(
+                    totalTimeMs = 90_000L,
+                    betweenPointsTimeMs = 22_000L,
+                    timeoutTimeMs = 5_000L,
+                    halftimeTimeMs = 10_000L,
+                    pureGameTimeMs = 53_000L,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `fails with participant identifier when participant statistics are missing`() {
+        val statistics = reversedStatistics().copy(
+            playerStatistics = reversedStatistics().playerStatistics.filterNot { it.participantId == PLAYER_ID },
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy { mapper.toResponse(match(), statistics) }
+            .withMessageContaining(PLAYER_ID.toString())
+    }
+
+    @Test
+    fun `fails with team identifier when team statistics are missing`() {
+        val statistics = reversedStatistics().copy(
+            teamStatistics = reversedStatistics().teamStatistics.filterNot { it.teamId == TEAM_1_ID },
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy { mapper.toResponse(match(), statistics) }
+            .withMessageContaining(TEAM_1_ID.toString())
+    }
+
+    @Test
+    fun `fails with display snapshot evidence when team name is missing`() {
+        val match = match().copy(teamNamesById = mapOf(TEAM_2_ID to "Swift Foxes"))
+
+        assertThatIllegalStateException()
+            .isThrownBy { mapper.toResponse(match, reversedStatistics()) }
+            .withMessageContaining("Display snapshot missing")
+            .withMessageContaining(TEAM_1_ID.toString())
+    }
+
+    private fun match() = Match(
+        id = MATCH_ID,
+        teamIds = listOf(TEAM_1_ID, TEAM_2_ID),
+        participantsByTeam = mapOf(
+            TEAM_1_ID to listOf(
+                MatchParticipant.player(
+                    matchId = MATCH_ID,
+                    teamId = TEAM_1_ID,
+                    playerId = PLAYER_ID,
+                    firstName = "Ivan",
+                    lastName = "Ivanov",
+                    number = 17,
+                ),
+                MatchParticipant(
+                    matchId = MATCH_ID,
+                    participantId = UNKNOWN_ID,
+                    teamId = TEAM_1_ID,
+                    kind = MatchParticipantKind.UNKNOWN,
+                    unknownSlot = 1,
+                ),
+            ),
+            TEAM_2_ID to emptyList(),
+        ),
+        teamNamesById = mapOf(
+            TEAM_1_ID to "Flying Bears",
+            TEAM_2_ID to "Swift Foxes",
+        ),
+    )
+
+    private fun reversedStatistics() = MatchStatistics(
+        playerStatistics = listOf(
+            PlayerStatistics(
+                participantId = UNKNOWN_ID,
+                attack = PlayerAttackStatistics(
+                    passes = 6,
+                    catches = 5,
+                    assists = 1,
+                    goals = 1,
+                    dropsOnMarker = 2,
+                    dropsOnField = 3,
+                    incompletePasses = 4,
+                    callahanDrops = 0,
+                    discPossessions = 9,
+                    pulls = 2,
+                    bricks = 1,
+                ),
+                defense = DefenseStatistics(
+                    blocks = 1,
+                    blocksAsMarker = 0,
+                    blocksAsFieldPlayer = 1,
+                    interceptions = 2,
+                    callahans = 0,
+                ),
+                time = PlayerTimeStatistics(
+                    totalPossessionTime = Duration.ofSeconds(9),
+                    averagePossessionTime = Duration.ofSeconds(1),
+                ),
+            ),
+            PlayerStatistics(
+                participantId = PLAYER_ID,
+                attack = PlayerAttackStatistics(
+                    passes = 12,
+                    catches = 11,
+                    assists = 3,
+                    goals = 2,
+                    dropsOnMarker = 1,
+                    dropsOnField = 2,
+                    incompletePasses = 4,
+                    callahanDrops = 1,
+                    discPossessions = 15,
+                    pulls = 5,
+                    bricks = 1,
+                ),
+                defense = DefenseStatistics(
+                    blocks = 2,
+                    blocksAsMarker = 1,
+                    blocksAsFieldPlayer = 1,
+                    interceptions = 3,
+                    callahans = 1,
+                ),
+                time = PlayerTimeStatistics(
+                    totalPossessionTime = Duration.ofSeconds(21),
+                    averagePossessionTime = Duration.ofMillis(1_500),
+                ),
+            ),
+        ),
+        teamStatistics = listOf(
+            TeamStatistics(
+                teamId = TEAM_2_ID,
+                attack = TeamAttackStatistics(
+                    score = 5,
+                    completePasses = 24,
+                    allPasses = 29,
+                    pulls = 6,
+                    bricks = 1,
+                    possessions = 12,
+                ),
+                defense = DefenseStatistics(
+                    blocks = 2,
+                    blocksAsMarker = 1,
+                    blocksAsFieldPlayer = 1,
+                    interceptions = 2,
+                    callahans = 0,
+                ),
+                time = TeamTimeStatistics(
+                    totalPossessionTime = Duration.ofSeconds(36),
+                    totalTimeBetweenPoints = Duration.ofSeconds(10),
+                    totalTimeSpentOnTimeouts = Duration.ofSeconds(2),
+                ),
+            ),
+            TeamStatistics(
+                teamId = TEAM_1_ID,
+                attack = TeamAttackStatistics(
+                    score = 7,
+                    completePasses = 31,
+                    allPasses = 37,
+                    pulls = 8,
+                    bricks = 2,
+                    possessions = 14,
+                ),
+                defense = DefenseStatistics(
+                    blocks = 3,
+                    blocksAsMarker = 1,
+                    blocksAsFieldPlayer = 2,
+                    interceptions = 4,
+                    callahans = 1,
+                ),
+                time = TeamTimeStatistics(
+                    totalPossessionTime = Duration.ofSeconds(42),
+                    totalTimeBetweenPoints = Duration.ofSeconds(12),
+                    totalTimeSpentOnTimeouts = Duration.ofSeconds(3),
+                ),
+            ),
+        ),
+        timeStatistics = MatchTimeStatistics(
+            totalTime = Duration.ofSeconds(90),
+            timeSpentBetweenPoints = Duration.ofSeconds(22),
+            timeSpentOnTimeouts = Duration.ofSeconds(5),
+            timeSpentOnHalftime = Duration.ofSeconds(10),
+            pureGameTime = Duration.ofSeconds(53),
+        ),
+    )
+
+    private companion object {
+        val MATCH_ID: UUID = UUID.fromString("10000000-0000-0000-0000-000000000001")
+        val TEAM_1_ID: UUID = UUID.fromString("20000000-0000-0000-0000-000000000001")
+        val TEAM_2_ID: UUID = UUID.fromString("20000000-0000-0000-0000-000000000002")
+        val PLAYER_ID: UUID = UUID.fromString("30000000-0000-0000-0000-000000000001")
+        val UNKNOWN_ID: UUID = UUID.fromString("30000000-0000-0000-0000-000000000002")
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/migration/MatchDisplaySnapshotMigrationTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/migration/MatchDisplaySnapshotMigrationTest.kt
@@ -1,0 +1,51 @@
+package com.github.mihanizzm.ultistats.migration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.ClassPathResource
+import org.springframework.jdbc.datasource.init.ScriptUtils
+import java.sql.DriverManager
+
+class MatchDisplaySnapshotMigrationTest {
+    @Test
+    fun `V3 backfills display snapshots and keeps unknown names empty`() {
+        DriverManager.getConnection(
+            "jdbc:h2:mem:match_snapshot_migration;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE",
+        ).use { connection ->
+            connection.createStatement().use { sql ->
+                sql.execute("CREATE TABLE teams (id UUID PRIMARY KEY, name VARCHAR(255) NOT NULL)")
+                sql.execute("CREATE TABLE players (id UUID PRIMARY KEY, first_name VARCHAR(255) NOT NULL, last_name VARCHAR(255) NOT NULL)")
+                sql.execute("CREATE TABLE matches (id UUID PRIMARY KEY)")
+                sql.execute("CREATE TABLE match_teams (match_id UUID NOT NULL, team_id UUID NOT NULL, position INTEGER NOT NULL, PRIMARY KEY (match_id, team_id))")
+                sql.execute("CREATE TABLE match_participants (match_id UUID NOT NULL, participant_id UUID NOT NULL, team_id UUID NOT NULL, kind VARCHAR(16) NOT NULL, unknown_slot INTEGER, number INTEGER, PRIMARY KEY (match_id, participant_id))")
+                sql.execute("INSERT INTO teams (id,name) VALUES ('00000000-0000-0000-0000-000000000001','Original team')")
+                sql.execute("INSERT INTO players (id,first_name,last_name) VALUES ('00000000-0000-0000-0000-000000000010','Ivan','Ivanov')")
+                sql.execute("INSERT INTO matches (id) VALUES ('00000000-0000-0000-0000-000000000100')")
+                sql.execute("INSERT INTO match_teams (match_id,team_id,position) VALUES ('00000000-0000-0000-0000-000000000100','00000000-0000-0000-0000-000000000001',1)")
+                sql.execute("INSERT INTO match_participants (match_id,participant_id,team_id,kind,number) VALUES ('00000000-0000-0000-0000-000000000100','00000000-0000-0000-0000-000000000010','00000000-0000-0000-0000-000000000001','PLAYER',7)")
+                sql.execute("INSERT INTO match_participants (match_id,participant_id,team_id,kind,unknown_slot) VALUES ('00000000-0000-0000-0000-000000000100','00000000-0000-0000-0000-000000000011','00000000-0000-0000-0000-000000000001','UNKNOWN',1)")
+            }
+            ScriptUtils.executeSqlScript(
+                connection,
+                ClassPathResource("db/migration/V3__add_match_display_snapshots.sql"),
+            )
+            connection.createStatement().use { sql ->
+                sql.executeQuery("SELECT team_name FROM match_teams").use { row ->
+                    assertThat(row.next()).isTrue()
+                    assertThat(row.getString("team_name")).isEqualTo("Original team")
+                }
+                sql.executeQuery(
+                    "SELECT kind,first_name,last_name FROM match_participants ORDER BY kind",
+                ).use { rows ->
+                    assertThat(rows.next()).isTrue()
+                    assertThat(rows.getString("first_name")).isEqualTo("Ivan")
+                    assertThat(rows.getString("last_name")).isEqualTo("Ivanov")
+                    assertThat(rows.next()).isTrue()
+                    assertThat(rows.getString("kind")).isEqualTo("UNKNOWN")
+                    assertThat(rows.getString("first_name")).isNull()
+                    assertThat(rows.getString("last_name")).isNull()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/service/StatisticsServiceImplTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/service/StatisticsServiceImplTest.kt
@@ -26,20 +26,6 @@ class StatisticsServiceImplTest : MatchAbstractTest() {
     }
 
     @Test
-    fun `Создание пустой статистики`() {
-        val teamIds = listOf(TEAM_1.id, TEAM_2.id)
-        val expectedStats = MatchStatistics(
-            playerStatistics = (PLAYERS_1 + PLAYERS_2).map { PlayerStatistics(it.id) },
-            teamStatistics = listOf(TEAM_1, TEAM_2)
-                .map { TeamStatistics(it.id) },
-        )
-
-        val actual = statisticsService.emptyStatistics(teamIds)
-
-        assertThat(actual).isEqualTo(expectedStats)
-    }
-
-    @Test
     fun `Незавершенный пас записывается бросающему`() {
         MATCH.events.add(
             OnePlayerEvent(UUIDS[2], Instant.now(), EventType.INCOMPLETE_PASS),

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE matches (
 CREATE TABLE match_teams (
     match_id UUID NOT NULL REFERENCES matches(id),
     team_id UUID NOT NULL REFERENCES teams(id),
+    team_name VARCHAR(255) NOT NULL,
     position INTEGER NOT NULL,
     score INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (match_id, team_id),
@@ -61,6 +62,8 @@ CREATE TABLE match_participants (
     team_id UUID NOT NULL,
     kind VARCHAR(16) NOT NULL,
     unknown_slot INTEGER,
+    first_name VARCHAR(255),
+    last_name VARCHAR(255),
     number INTEGER,
     PRIMARY KEY (match_id, participant_id),
     FOREIGN KEY (match_id, team_id) REFERENCES match_teams(match_id, team_id),
@@ -71,6 +74,11 @@ CREATE TABLE match_participants (
         (kind = 'PLAYER' AND unknown_slot IS NULL)
         OR
         (kind = 'UNKNOWN' AND unknown_slot IN (1, 2) AND number IS NULL)
+    ),
+    CHECK (
+        (kind = 'PLAYER' AND first_name IS NOT NULL AND last_name IS NOT NULL)
+        OR
+        (kind = 'UNKNOWN' AND first_name IS NULL AND last_name IS NULL)
     )
 );
 


### PR DESCRIPTION
## Что сделано

- Добавлены match-scoped snapshots названий команд и имён игроков с Flyway-миграцией V3 и backfill существующих матчей.
- `MatchResponse` и список матчей используют сохранённые имена, поэтому переименование, смена номера или soft-delete справочных сущностей не меняют исторический матч.
- `StatisticsService` рассчитывает статистику из одного уже загруженного `Match`, без повторной загрузки и без обращения к текущим составам.
- Введены явные response DTO и grouped Statistics API: команды содержат своих участников, а все длительности возвращаются числовыми значениями в миллисекундах (`*Ms`).
- Добавлены `StatisticsFacade`, структурированный `404 ProblemDetail`, fail-fast проверки несогласованных ID и актуальное OpenAPI-описание.
- Сохранены два UNKNOWN-участника на каждую команду и явные nullable-поля их идентичности.

Старый Statistics JSON заменён в существующем v1 endpoint без legacy/v2: активных потребителей старого контракта пока нет.

## Проверка

- Java 21: `./gradlew cleanTest test --rerun-tasks` — 184 теста, 0 failures/errors/skips.
- PostgreSQL 16.13: успешный upgrade представительной базы V1/V2 → V3 и Hibernate initialization.
- Чистая PostgreSQL-база: Flyway V1, V2 и V3 применились успешно.
- Проверен backfill: команда и PLAYER получили исходные имена, у UNKNOWN оба имени остались SQL `NULL`.
- Whole-branch review и финальный contract review: Critical/Important/Nit — 0.

Closes #79
