### PR TITLE
Добавить экспорт статистики матча в ZIP

### DIFF
--- a/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsController.kt
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
@@ -61,6 +63,46 @@ class StatisticsController(
         ?.let { ResponseEntity.ok(it) }
         ?: notFound(matchId, request)
 
+    @GetMapping("/export", produces = [APPLICATION_ZIP_VALUE])
+    @Operation(summary = "Экспортировать статистику матча в ZIP с CSV-таблицами")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "ZIP-архив со статистикой матча",
+                content = [Content(
+                    mediaType = APPLICATION_ZIP_VALUE,
+                    schema = Schema(type = "string", format = "binary"),
+                )],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Матч не найден",
+                content = [Content(
+                    mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                    schema = Schema(implementation = ProblemDetail::class),
+                )],
+            ),
+        ],
+    )
+    fun exportStatistics(
+        @PathVariable matchId: UUID,
+        request: HttpServletRequest,
+    ): ResponseEntity<*> = statisticsFacade.export(matchId)
+        ?.let { archive ->
+            ResponseEntity.ok()
+                .contentType(APPLICATION_ZIP)
+                .header(
+                    HttpHeaders.CONTENT_DISPOSITION,
+                    ContentDisposition.attachment()
+                        .filename("match_${matchId}_statistics.zip")
+                        .build()
+                        .toString(),
+                )
+                .body(archive)
+        }
+        ?: notFound(matchId, request)
+
     private fun notFound(matchId: UUID, request: HttpServletRequest): ResponseEntity<ProblemDetail> {
         val problem = MatchProblem(
             code = MatchProblemCode.RESOURCE_NOT_FOUND,
@@ -68,6 +110,12 @@ class StatisticsController(
             detail = "Match $matchId not found",
         )
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .contentType(MediaType.APPLICATION_PROBLEM_JSON)
             .body(problem.toProblemDetail(HttpStatus.NOT_FOUND, URI.create(request.requestURI)))
+    }
+
+    companion object {
+        private const val APPLICATION_ZIP_VALUE = "application/zip"
+        private val APPLICATION_ZIP = MediaType("application", "zip")
     }
 }

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/export/StatisticsZipExporter.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/export/StatisticsZipExporter.kt
@@ -1,0 +1,115 @@
+package com.github.mihanizzm.ultistats.export
+
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import org.springframework.stereotype.Component
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@Component
+class StatisticsZipExporter {
+    fun export(statistics: MatchStatisticsResponse): ByteArray = ByteArrayOutputStream().use { output ->
+        ZipOutputStream(output).use { zip ->
+            zip.writeEntry("match.csv", matchCsv(statistics))
+            zip.writeEntry("teams.csv", teamsCsv(statistics))
+            zip.writeEntry("participants.csv", participantsCsv(statistics))
+        }
+        output.toByteArray()
+    }
+
+    private fun matchCsv(statistics: MatchStatisticsResponse): String = buildString {
+        append("match_id,total_time_ms,between_points_time_ms,timeout_time_ms,halftime_time_ms,pure_game_time_ms\r\n")
+        appendCsvRow(
+            statistics.matchId,
+            statistics.time.totalTimeMs,
+            statistics.time.betweenPointsTimeMs,
+            statistics.time.timeoutTimeMs,
+            statistics.time.halftimeTimeMs,
+            statistics.time.pureGameTimeMs,
+        )
+    }
+
+    private fun teamsCsv(statistics: MatchStatisticsResponse): String = buildString {
+        append("match_id,team_id,team_name,score,complete_passes,all_passes,pulls,bricks,possessions,blocks,blocks_as_marker,blocks_as_field_player,interceptions,callahans,possession_time_ms,between_points_time_ms,timeout_time_ms\r\n")
+        statistics.teams.forEach { team ->
+            appendCsvRow(
+                statistics.matchId,
+                team.teamId,
+                team.teamName,
+                team.attack.score,
+                team.attack.completePasses,
+                team.attack.allPasses,
+                team.attack.pulls,
+                team.attack.bricks,
+                team.attack.possessions,
+                team.defense.blocks,
+                team.defense.blocksAsMarker,
+                team.defense.blocksAsFieldPlayer,
+                team.defense.interceptions,
+                team.defense.callahans,
+                team.time.possessionTimeMs,
+                team.time.betweenPointsTimeMs,
+                team.time.timeoutTimeMs,
+            )
+        }
+    }
+
+    private fun participantsCsv(statistics: MatchStatisticsResponse): String = buildString {
+        append("match_id,team_id,team_name,participant_id,kind,unknown_slot,first_name,last_name,display_name,number,passes,catches,assists,goals,drops_on_marker,drops_on_field,incomplete_passes,callahan_drops,disc_possessions,pulls,bricks,blocks,blocks_as_marker,blocks_as_field_player,interceptions,callahans,possession_time_ms,average_possession_time_ms\r\n")
+        statistics.teams.forEach { team ->
+            team.participants.forEach { participant ->
+                appendCsvRow(
+                    statistics.matchId,
+                    team.teamId,
+                    team.teamName,
+                    participant.participantId,
+                    participant.kind,
+                    participant.unknownSlot,
+                    participant.firstName,
+                    participant.lastName,
+                    participant.displayName,
+                    participant.number,
+                    participant.attack.passes,
+                    participant.attack.catches,
+                    participant.attack.assists,
+                    participant.attack.goals,
+                    participant.attack.dropsOnMarker,
+                    participant.attack.dropsOnField,
+                    participant.attack.incompletePasses,
+                    participant.attack.callahanDrops,
+                    participant.attack.discPossessions,
+                    participant.attack.pulls,
+                    participant.attack.bricks,
+                    participant.defense.blocks,
+                    participant.defense.blocksAsMarker,
+                    participant.defense.blocksAsFieldPlayer,
+                    participant.defense.interceptions,
+                    participant.defense.callahans,
+                    participant.time.possessionTimeMs,
+                    participant.time.averagePossessionTimeMs,
+                )
+            }
+        }
+    }
+
+    private fun StringBuilder.appendCsvRow(vararg values: Any?) {
+        append(values.joinToString(",") { value -> value.toCsvValue() })
+        append("\r\n")
+    }
+
+    private fun Any?.toCsvValue(): String {
+        if (this == null) return ""
+        val value = toString()
+        return if (value.any { it == ',' || it == '"' || it == '\r' || it == '\n' }) {
+            "\"${value.replace("\"", "\"\"")}\""
+        } else {
+            value
+        }
+    }
+
+    private fun ZipOutputStream.writeEntry(name: String, content: String) {
+        putNextEntry(ZipEntry(name))
+        write(content.toByteArray(Charsets.UTF_8))
+        closeEntry()
+    }
+}

--- a/src/main/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacade.kt
+++ b/src/main/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacade.kt
@@ -1,6 +1,7 @@
 package com.github.mihanizzm.ultistats.facade
 
 import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.export.StatisticsZipExporter
 import com.github.mihanizzm.ultistats.mapper.StatisticsResponseMapper
 import com.github.mihanizzm.ultistats.service.MatchService
 import com.github.mihanizzm.ultistats.service.statistics.StatisticsService
@@ -12,6 +13,7 @@ class StatisticsFacade(
     private val matchService: MatchService,
     private val statisticsService: StatisticsService,
     private val responseMapper: StatisticsResponseMapper,
+    private val zipExporter: StatisticsZipExporter,
 ) {
     fun get(matchId: UUID): MatchStatisticsResponse? {
         val match = matchService.get(matchId) ?: return null
@@ -20,4 +22,6 @@ class StatisticsFacade(
             statisticsService.recalculateMatchStatistics(match),
         )
     }
+
+    fun export(matchId: UUID): ByteArray? = get(matchId)?.let(zipExporter::export)
 }

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/controller/StatisticsControllerTest.kt
@@ -20,14 +20,18 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.io.ByteArrayInputStream
 import java.time.Instant
 import java.util.UUID
+import java.util.zip.ZipInputStream
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -210,6 +214,46 @@ class StatisticsControllerTest {
     }
 
     @Test
+    fun `Экспорт скачивает ZIP с CSV таблицами и snapshot данными`() {
+        val response = mockMvc.perform(
+            get("/api/v1/matches/${match.id}/statistics/export")
+                .accept("application/zip"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType("application/zip"))
+            .andExpect(
+                header().string(
+                    HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment; filename=\"match_${match.id}_statistics.zip\"",
+                ),
+            )
+            .andReturn()
+
+        val entries = readZipEntries(response.response.contentAsByteArray)
+        assertThat(entries.keys).containsExactly("match.csv", "teams.csv", "participants.csv")
+        assertThat(entries.getValue("match.csv")).startsWith("match_id,total_time_ms,")
+        assertThat(entries.getValue("teams.csv"))
+            .contains("${match.id},${team1.id},Команда 1,")
+            .contains("${match.id},${team2.id},Команда 2,")
+        assertThat(entries.getValue("participants.csv"))
+            .contains("${players1[0].id},PLAYER,,Игрок,Один,Игрок Один,1,")
+            .contains("UNKNOWN,1,,,Неизвестный игрок 1,,")
+    }
+
+    @Test
+    fun `Экспорт отсутствующего матча возвращает структурированный 404`() {
+        val missingId = UUID.randomUUID()
+        val instance = "/api/v1/matches/$missingId/statistics/export"
+
+        mockMvc.perform(get(instance).accept("application/zip"))
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+            .andExpect(jsonPath("$.detail").value("Match $missingId not found"))
+            .andExpect(jsonPath("$.instance").value(instance))
+    }
+
+    @Test
     fun `OpenAPI документирует стабильный ответ и ProblemDetail`() {
         mockMvc.perform(get("/v3/api-docs"))
             .andExpect(status().isOk)
@@ -221,6 +265,24 @@ class StatisticsControllerTest {
             .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['200'].content['application/json'].example.teams[0].participants[0].time.possessionTimeMs").isNumber)
             .andExpect(jsonPath("$.paths['/api/v1/matches/{matchId}/statistics'].get.responses['404'].content['application/problem+json'].schema['\$ref']")
                 .value("#/components/schemas/ProblemDetail"))
+    }
+
+    @Test
+    fun `OpenAPI документирует ZIP экспорт и ProblemDetail`() {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(
+                jsonPath("$.paths['/api/v1/matches/{matchId}/statistics/export'].get.responses['200'].content['application/zip'].schema.type")
+                    .value("string"),
+            )
+            .andExpect(
+                jsonPath("$.paths['/api/v1/matches/{matchId}/statistics/export'].get.responses['200'].content['application/zip'].schema.format")
+                    .value("binary"),
+            )
+            .andExpect(
+                jsonPath("$.paths['/api/v1/matches/{matchId}/statistics/export'].get.responses['404'].content['application/problem+json'].schema['\$ref']")
+                    .value("#/components/schemas/ProblemDetail"),
+            )
     }
 
     private fun createTestTeam(name: String): Pair<Team, List<Player>> {
@@ -241,6 +303,17 @@ class StatisticsControllerTest {
         val match = Match(id = UUID.randomUUID(), teamIds = listOf(team1.id, team2.id))
         matchService.create(match)
         return match
+    }
+
+    private fun readZipEntries(content: ByteArray): Map<String, String> = buildMap {
+        ZipInputStream(ByteArrayInputStream(content)).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                put(entry.name, zip.readBytes().toString(Charsets.UTF_8))
+                zip.closeEntry()
+                entry = zip.nextEntry
+            }
+        }
     }
 
     companion object {

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/export/StatisticsZipExporterTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/export/StatisticsZipExporterTest.kt
@@ -1,0 +1,155 @@
+package com.github.mihanizzm.ultistats.export
+
+import com.github.mihanizzm.ultistats.dto.response.statistics.DefenseStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.MatchTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.ParticipantStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.PlayerAttackStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.PlayerTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamAttackStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamStatisticsResponse
+import com.github.mihanizzm.ultistats.dto.response.statistics.TeamTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.model.MatchParticipantKind
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.util.UUID
+import java.util.zip.ZipInputStream
+
+@Suppress("NonAsciiCharacters")
+class StatisticsZipExporterTest {
+    private val exporter = StatisticsZipExporter()
+
+    @Test
+    fun `Архив содержит нормализованные таблицы и общую статистику матча`() {
+        val response = MatchStatisticsResponse(
+            matchId = MATCH_ID,
+            teams = emptyList(),
+            time = MatchTimeStatisticsResponse(
+                totalTimeMs = 120_000,
+                betweenPointsTimeMs = 15_000,
+                timeoutTimeMs = 30_000,
+                halftimeTimeMs = 45_000,
+                pureGameTimeMs = 30_000,
+            ),
+        )
+
+        val entries = readEntries(exporter.export(response))
+
+        assertThat(entries.keys).containsExactly("match.csv", "teams.csv", "participants.csv")
+        assertThat(entries.getValue("match.csv")).isEqualTo(
+            "match_id,total_time_ms,between_points_time_ms,timeout_time_ms,halftime_time_ms,pure_game_time_ms\r\n" +
+                "$MATCH_ID,120000,15000,30000,45000,30000\r\n",
+        )
+    }
+
+    @Test
+    fun `Командная таблица содержит идентификаторы статистику и корректно экранированное имя`() {
+        val response = MatchStatisticsResponse(
+            matchId = MATCH_ID,
+            teams = listOf(
+                TeamStatisticsResponse(
+                    teamId = TEAM_ID,
+                    teamName = "Команда, \"А\"\nЮниоры",
+                    attack = TeamAttackStatisticsResponse(
+                        score = 15,
+                        completePasses = 120,
+                        allPasses = 135,
+                        pulls = 8,
+                        bricks = 1,
+                        possessions = 25,
+                    ),
+                    defense = DefenseStatisticsResponse(
+                        blocks = 8,
+                        blocksAsMarker = 5,
+                        blocksAsFieldPlayer = 3,
+                        interceptions = 2,
+                        callahans = 1,
+                    ),
+                    time = TeamTimeStatisticsResponse(
+                        possessionTimeMs = 930_000,
+                        betweenPointsTimeMs = 70_000,
+                        timeoutTimeMs = 60_000,
+                    ),
+                    participants = emptyList(),
+                ),
+            ),
+            time = MatchTimeStatisticsResponse(1_200_000, 70_000, 60_000, 0, 1_070_000),
+        )
+
+        val teamsCsv = readEntries(exporter.export(response)).getValue("teams.csv")
+
+        assertThat(teamsCsv).isEqualTo(
+            "match_id,team_id,team_name,score,complete_passes,all_passes,pulls,bricks,possessions,blocks,blocks_as_marker,blocks_as_field_player,interceptions,callahans,possession_time_ms,between_points_time_ms,timeout_time_ms\r\n" +
+                "$MATCH_ID,$TEAM_ID,\"Команда, \"\"А\"\"\nЮниоры\",15,120,135,8,1,25,8,5,3,2,1,930000,70000,60000\r\n",
+        )
+    }
+
+    @Test
+    fun `Таблица участников сохраняет игрока неизвестный слот и все показатели`() {
+        val player = ParticipantStatisticsResponse(
+            participantId = PLAYER_ID,
+            kind = MatchParticipantKind.PLAYER,
+            unknownSlot = null,
+            firstName = "Иван",
+            lastName = "Иванов",
+            displayName = "Иван, \"Молния\"\nИванов",
+            number = 17,
+            attack = PlayerAttackStatisticsResponse(11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21),
+            defense = DefenseStatisticsResponse(22, 23, 24, 25, 26),
+            time = PlayerTimeStatisticsResponse(27_000, 28_000),
+        )
+        val unknown = ParticipantStatisticsResponse(
+            participantId = UNKNOWN_ID,
+            kind = MatchParticipantKind.UNKNOWN,
+            unknownSlot = 2,
+            firstName = null,
+            lastName = null,
+            displayName = "Неизвестный игрок 2",
+            number = null,
+            attack = PlayerAttackStatisticsResponse(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            defense = DefenseStatisticsResponse(0, 0, 0, 0, 0),
+            time = PlayerTimeStatisticsResponse(0, 0),
+        )
+        val response = MatchStatisticsResponse(
+            matchId = MATCH_ID,
+            teams = listOf(
+                TeamStatisticsResponse(
+                    teamId = TEAM_ID,
+                    teamName = "Команда 1",
+                    attack = TeamAttackStatisticsResponse(0, 0, 0, 0, 0, 0),
+                    defense = DefenseStatisticsResponse(0, 0, 0, 0, 0),
+                    time = TeamTimeStatisticsResponse(0, 0, 0),
+                    participants = listOf(player, unknown),
+                ),
+            ),
+            time = MatchTimeStatisticsResponse(0, 0, 0, 0, 0),
+        )
+
+        val participantsCsv = readEntries(exporter.export(response)).getValue("participants.csv")
+
+        assertThat(participantsCsv).isEqualTo(
+            "match_id,team_id,team_name,participant_id,kind,unknown_slot,first_name,last_name,display_name,number,passes,catches,assists,goals,drops_on_marker,drops_on_field,incomplete_passes,callahan_drops,disc_possessions,pulls,bricks,blocks,blocks_as_marker,blocks_as_field_player,interceptions,callahans,possession_time_ms,average_possession_time_ms\r\n" +
+                "$MATCH_ID,$TEAM_ID,Команда 1,$PLAYER_ID,PLAYER,,Иван,Иванов,\"Иван, \"\"Молния\"\"\nИванов\",17,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27000,28000\r\n" +
+                "$MATCH_ID,$TEAM_ID,Команда 1,$UNKNOWN_ID,UNKNOWN,2,,,Неизвестный игрок 2,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\r\n",
+        )
+    }
+
+    private fun readEntries(content: ByteArray): Map<String, String> = buildMap {
+        ZipInputStream(ByteArrayInputStream(content)).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                put(entry.name, zip.readBytes().toString(Charsets.UTF_8))
+                zip.closeEntry()
+                entry = zip.nextEntry
+            }
+        }
+    }
+
+    companion object {
+        private val MATCH_ID = UUID.fromString("00000000-0000-0000-0000-000000000100")
+        private val TEAM_ID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        private val PLAYER_ID = UUID.fromString("00000000-0000-0000-0000-000000000010")
+        private val UNKNOWN_ID = UUID.fromString("00000000-0000-0000-0000-000000000011")
+    }
+}

--- a/src/test/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacadeTest.kt
+++ b/src/test/kotlin/com/github/mihanizzm/ultistats/facade/StatisticsFacadeTest.kt
@@ -2,6 +2,7 @@ package com.github.mihanizzm.ultistats.facade
 
 import com.github.mihanizzm.ultistats.dto.response.statistics.MatchStatisticsResponse
 import com.github.mihanizzm.ultistats.dto.response.statistics.MatchTimeStatisticsResponse
+import com.github.mihanizzm.ultistats.export.StatisticsZipExporter
 import com.github.mihanizzm.ultistats.mapper.StatisticsResponseMapper
 import com.github.mihanizzm.ultistats.model.Match
 import com.github.mihanizzm.ultistats.model.statistics.MatchStatistics
@@ -21,7 +22,7 @@ class StatisticsFacadeTest {
     private val matchService = mock(MatchService::class.java)
     private val statisticsService = mock(StatisticsService::class.java)
     private val responseMapper = mock(StatisticsResponseMapper::class.java)
-    private val facade = StatisticsFacade(matchService, statisticsService, responseMapper)
+    private val facade = StatisticsFacade(matchService, statisticsService, responseMapper, StatisticsZipExporter())
 
     @Test
     fun `loads match once and propagates the same instance through calculation and mapping`() {


### PR DESCRIPTION
## Что сделано

- добавлен `GET /api/v1/matches/{matchId}/statistics/export` с ответом `application/zip`;
- архив содержит нормализованные `match.csv`, `teams.csv` и `participants.csv`;
- CSV сохраняют идентификаторы и snapshot-имена команд/участников, включая UNKNOWN-слоты, и все текущие показатели Statistics API;
- реализовано экранирование запятых, кавычек и переносов строк, nullable-поля экспортируются пустыми значениями;
- расчёт и отображаемые данные переиспользуют существующий `MatchStatisticsResponse`;
- добавлены структурированный `404 application/problem+json` и OpenAPI binary-контракт.

## Проверка

- `./gradlew cleanTest test --rerun-tasks` — 190 тестов, 0 failures/errors/skips;
- unit-тесты проверяют точные заголовки, строки, UTF-8/кириллицу, CRLF, экранирование и UNKNOWN-поля;
- Spring Boot/MockMvc тест проверяет реальный download, заголовки, содержимое ZIP, `404` и OpenAPI;
- финальный contract-review: 0 Critical, 0 Important, 0 Nit.

Closes #35
